### PR TITLE
Website: Add LogLM and open-weights (Sec-8B, Seneca-QwQ-32B, GLM-5.2) alongside the 3 frontier LLMs.

### DIFF
--- a/docs/website/css/style.css
+++ b/docs/website/css/style.css
@@ -127,6 +127,42 @@ a:hover { text-decoration: underline; }
 }
 .repo-pill-count:empty { display: none; }
 
+/* ---------- announcement strips ---------- */
+.announcements {
+  border-bottom: 1px solid var(--border);
+}
+.announcement {
+  border-bottom: 1px solid var(--border);
+}
+.announcement:last-child { border-bottom: 0; }
+.announcement-inner {
+  max-width: 1100px; margin: 0 auto;
+  padding: 12px 24px;
+  display: flex; align-items: center; gap: 14px;
+  font-size: 16px;
+  font-weight: 600;
+  color: var(--fg);
+}
+.announcement--new    { background: #ecfeff; border-left: 3px solid var(--loglm); }
+.announcement--coming { background: #fffbeb; border-left: 3px solid var(--warn); }
+.announcement-badge {
+  display: inline-flex; align-items: center; gap: 5px;
+  font-family: var(--mono); font-size: var(--text-micro); font-weight: 700;
+  padding: 4px 10px; border-radius: 999px;
+  white-space: nowrap; letter-spacing: 0.04em;
+  border: 1px solid transparent;
+}
+.announcement-badge--new    { background: #cffafe; color: #0e7490; border-color: #a5f3fc; }
+.announcement-badge--coming { background: #fef3c7; color: #b45309; border-color: #fde68a; }
+.announcement-text a {
+  color: inherit; font-weight: 600;
+  border-bottom: 1px solid currentColor;
+  padding-bottom: 1px;
+}
+.announcement-text a:hover { text-decoration: none; color: var(--accent); border-bottom-color: var(--accent); }
+.announcement--new    .announcement-text a { color: #0e7490; }
+.announcement--coming .announcement-text a { color: #b45309; }
+
 /* ---------- sections ---------- */
 section {
   max-width: 1100px; margin: 0 auto;
@@ -134,6 +170,8 @@ section {
   scroll-margin-top: 72px;
 }
 section + section { border-top: 1px solid var(--border); }
+/* The first section (#overview) sits directly under the announcement strips; drop its top padding. */
+.announcements + section { padding-top: 32px; }
 
 .eyebrow {
   text-transform: uppercase;
@@ -238,6 +276,14 @@ h3 { font-size: var(--text-h3); line-height: 1.3; margin: 32px 0 12px; }
   }
 }
 .section-sub { font-size: var(--text-body); color: var(--fg-muted); margin: 0 0 20px; max-width: 900px; }
+.chart-footnote {
+  font-size: var(--text-small); color: var(--fg-muted);
+  margin: 12px 0 24px; max-width: 900px; line-height: 1.5;
+}
+.chart-footnote code {
+  font-family: var(--mono); font-size: var(--text-small);
+  background: transparent; padding: 0; color: var(--fg-muted); font-weight: 700;
+}
 .legend {
   font-size: var(--text-small); color: var(--fg-muted);
   display: flex; flex-wrap: wrap; gap: 8px 4px; align-items: center;
@@ -632,7 +678,7 @@ h3 { font-size: var(--text-h3); line-height: 1.3; margin: 32px 0 12px; }
 .chart-title { font-size: var(--text-body); font-weight: 600; margin-bottom: 4px; }
 .chart-sub { font-size: var(--text-small); color: var(--fg-muted); margin-bottom: 6px; }
 .chart-canvas { position: relative; height: 320px; }
-.chart-canvas--compact { height: 200px; }
+.chart-canvas--compact { height: 280px; }
 
 /* 3-column grid for the overall summary trio (Cost / FPR / Completion).
    Collapses to a single column on narrow screens. */
@@ -716,6 +762,7 @@ tbody tr:hover { background: #f9fafb; }
 tbody tr:last-child td { border-bottom: 0; }
 td.num, th.num { text-align: right; font-family: var(--mono); }
 td.provider-cell { font-family: var(--mono); font-weight: 500; }
+tr.row-ghost td { color: var(--fg-dim); font-style: italic; background: #f9fafb; }
 td.persona-cell { font-family: var(--mono); color: var(--fg-muted); }
 
 /* ---------- collapsibles ---------- */

--- a/docs/website/css/style.css
+++ b/docs/website/css/style.css
@@ -10,9 +10,14 @@
   --fg-dim: #9ca3af;
   --accent: #2563eb;
   --accent-soft: #dbeafe;
-  --anthropic: #d97706;  /* amber-600 */
-  --openai:    #059669;  /* emerald-600 */
-  --gemini:    #7c3aed;  /* violet-600 */
+  --anthropic:      #d97706;  /* amber-600 */
+  --openai:         #059669;  /* emerald-600 */
+  --gemini:         #7c3aed;  /* violet-600 */
+  --loglm:          #0891b2;  /* cyan-600 */
+  --oss:            #64748b;  /* slate-500 · shared OSS lane accent */
+  --foundation-sec: #2563eb;  /* blue-600 */
+  --seneca:         #db2777;  /* pink-600 */
+  --glm:            #65a30d;  /* lime-600 */
   --good: #16a34a;
   --warn: #d97706;
   --bad:  #dc2626;
@@ -143,6 +148,9 @@ h1 { font-size: var(--text-display); line-height: 1.05; margin-bottom: 8px; font
 h2 { font-size: var(--text-h2); line-height: 1.2; margin-bottom: 20px; }
 h3 { font-size: var(--text-h3); line-height: 1.3; margin: 32px 0 12px; }
 .lead { font-size: var(--text-title); color: var(--fg-muted); margin: 0 0 24px; max-width: 900px; }
+.lead-lanes { font-size: var(--text-title); color: var(--fg-muted); margin: 0 0 24px 22px; max-width: 900px; padding: 0; }
+.lead-lanes li { margin: 0 0 8px; line-height: 1.5; }
+.lead-lanes li strong { color: var(--fg); }
 .hero-tagline {
   font-size: var(--text-hero); line-height: 1.35;
   color: var(--fg); font-weight: 500;
@@ -543,6 +551,74 @@ h3 { font-size: var(--text-h3); line-height: 1.3; margin: 32px 0 12px; }
   padding: 1px 5px;
   border-radius: 4px;
   color: var(--fg);
+}
+
+/* ---------- Detection leaderboard (ranked, inline bars) ---------- */
+.leaderboard {
+  margin: 32px 0;
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  overflow: hidden;
+  background: var(--bg-card);
+  box-shadow: var(--shadow-sm);
+}
+.lb-row {
+  display: grid;
+  grid-template-columns: minmax(200px, 1.4fr) minmax(120px, auto) minmax(160px, 1.6fr) minmax(160px, 1.6fr) minmax(180px, 1.4fr);
+  align-items: center;
+  gap: 20px;
+  padding: 8px 20px;
+  border-bottom: 1px solid var(--border);
+}
+.lb-row:last-child { border-bottom: 0; }
+.lb-row--head {
+  background: #f9fafb;
+  font-family: var(--mono); font-size: var(--text-micro);
+  text-transform: uppercase; letter-spacing: 0.1em;
+  color: var(--fg-muted); font-weight: 600;
+  padding: 8px 20px;
+}
+
+.lb-name { line-height: 1.2; }
+.lb-name-sub { line-height: 1.2; }
+.lb-row--winner { background: linear-gradient(90deg, rgba(8,145,178,0.06), transparent 60%); }
+
+.lb-name { font-family: var(--mono); font-weight: 600; font-size: var(--text-body); color: var(--fg); }
+.lb-name-sub { font-family: var(--mono); font-size: var(--text-micro); color: var(--fg-muted); margin-top: 2px; }
+
+.lb-lane {
+  font-family: var(--mono); font-size: var(--text-micro); font-weight: 600;
+  padding: 3px 9px; border-radius: 999px;
+  white-space: nowrap; justify-self: start;
+}
+.lb-lane--frontier { background: #fef3c7; color: #92400e; }
+.lb-lane--open { background: #e2e8f0; color: #475569; }
+.lb-lane--purpose { background: #cffafe; color: #0e7490; }
+
+.lb-metric { display: flex; align-items: center; gap: 12px; }
+.lb-metric-num { font-family: var(--mono); font-weight: 700; font-size: var(--text-body); color: var(--fg); min-width: 3.2ch; }
+.lb-bar {
+  flex: 1; height: 6px;
+  background: #f3f4f6;
+  border-radius: 3px;
+  overflow: hidden;
+  position: relative;
+  min-width: 80px;
+}
+.lb-bar-fill {
+  position: absolute; top: 0; left: 0; bottom: 0;
+  border-radius: 3px;
+}
+
+.lb-note { font-size: var(--text-small); color: var(--fg-muted); }
+.lb-note code {
+  font-family: var(--mono); font-size: var(--text-micro);
+  background: #f3f4f6; padding: 1px 5px; border-radius: 4px; color: var(--fg);
+}
+.lb-note-caveat {
+  font-size: var(--text-micro); color: #b45309;
+  background: #fef3c7; padding: 1px 6px; border-radius: 4px; font-weight: 500;
+  margin-right: 6px;
 }
 /* ---------- chart container ---------- */
 .chart-wrap {

--- a/docs/website/index.html
+++ b/docs/website/index.html
@@ -271,6 +271,13 @@
       </div>
       <div class="cap-desc">IOC enrichment, threat-actor attribution, MITRE ATT&amp;CK mapping.</div>
     </div>
+    <div class="cap cap-vulnerability planned">
+      <div class="cap-head">
+        <div class="cap-title">Vulnerability detection and patching</div>
+        <span class="cap-badge">Roadmap</span>
+      </div>
+      <div class="cap-desc">Identify exploitable vulnerabilities across assets, prioritize by risk, and propose or apply patches.</div>
+    </div>
     <div class="cap cap-response exploring">
       <div class="cap-head">
         <div class="cap-title">Response &amp; remediation</div>
@@ -293,87 +300,143 @@
 <section id="detection">
   <div class="eyebrow">Capability · Live</div>
   <h2>Detection</h2>
+  <p class="lead">The Detection benchmark scores three lanes on 1,205 evaluation units:</p>
+  <ol class="lead-lanes">
+    <li><strong>Frontier LLMs.</strong> Claude Opus 4.7, GPT-5.4, Gemini 2.5 Pro.</li>
+    <li><strong>Open weights.</strong> Foundation-Sec-8B, Seneca-QwQ-32B, GLM 5.2.</li>
+    <li><strong>Foundation model for cybersecurity.</strong> LogLM, DeepTempo's encoder-only model.</li>
+  </ol>
   <p class="lead">
-    Each provider runs four analyst personas (<code>soc_analyst</code>,
-    <code>threat_analyst</code>, <code>adversary_hunter</code>,
-    <code>detection_engineer</code>) over the same evaluation units, calling
-    <a href="#persona-tools">network-flow tools</a> and submitting a per-unit verdict plus a list of flows
-    flagged malicious. We score every (provider × persona) pair on three F1
-    lenses (per-flow, per-pair, per-host), verdict accuracy, completion rate,
-    latency, and cost.
+    All LLMs run in the same <strong>detection harness</strong>: four analyst personas with <a href="#persona-tools">network-flow tools</a> submitting per-unit verdicts.
+    LogLM scores sequences directly, projected onto the eval-unit class prior.
   </p>
 
-  <div class="cards">
-    <div class="card card--slim anthropic">
-      <div class="card-head">
-        <div class="card-head-text">
-          <div class="card-provider">anthropic</div>
-          <div class="card-model">claude-opus-4-7</div>
-        </div>
-        <span class="card-pill card-pill--efficacy">
-          <svg viewBox="0 0 16 16" width="11" height="11" fill="currentColor" aria-hidden="true"><path d="M8 0l2 6h6l-5 3.5L13 16 8 12 3 16l2-6.5L0 6h6z"/></svg>
-          Best efficacy
-        </span>
-      </div>
-      <div class="card-stats-dual">
-        <div class="card-stat-cell">
-          <span class="card-stat-num">0.93</span>
-          <div class="card-stat-label">verdict F1</div>
-        </div>
-        <div class="card-stat-cell">
-          <span class="card-stat-num">0.65</span>
-          <div class="card-stat-label">per-flow F1</div>
-        </div>
-      </div>
-      <div class="card-stat-meta">best persona: <code>soc_analyst</code></div>
+  <div class="leaderboard">
+    <div class="lb-row lb-row--head">
+      <div>System</div>
+      <div>Lane</div>
+      <div>Verdict F1</div>
+      <div>Per-flow F1</div>
+      <div>Note</div>
     </div>
 
-    <div class="card card--slim gemini">
-      <div class="card-head">
-        <div class="card-head-text">
-          <div class="card-provider">gemini</div>
-          <div class="card-model">gemini-2.5-pro</div>
-        </div>
-        <span class="card-pill card-pill--balanced">
-          <svg viewBox="0 0 16 16" width="11" height="11" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M8 1v14M3 4l5 3 5-3M3 12l5-3 5 3"/></svg>
-          Most balanced
-        </span>
+    <div class="lb-row lb-row--winner">
+      <div>
+        <div class="lb-name">loglm</div>
+        <div class="lb-name-sub">deeptempo · projected</div>
       </div>
-      <div class="card-stats-dual">
-        <div class="card-stat-cell">
-          <span class="card-stat-num">0.88</span>
-          <div class="card-stat-label">verdict F1</div>
-        </div>
-        <div class="card-stat-cell">
-          <span class="card-stat-num">0.52</span>
-          <div class="card-stat-label">per-flow F1</div>
-        </div>
+      <span class="lb-lane lb-lane--purpose">Purpose-built</span>
+      <div class="lb-metric">
+        <span class="lb-metric-num">0.95</span>
+        <div class="lb-bar"><div class="lb-bar-fill" style="width:95%; background: var(--loglm);"></div></div>
       </div>
-      <div class="card-stat-meta">best persona: <code>soc_analyst</code></div>
+      <div class="lb-metric">
+        <span class="lb-metric-num">0.99</span>
+        <div class="lb-bar"><div class="lb-bar-fill" style="width:99%; background: var(--loglm);"></div></div>
+      </div>
+      <div class="lb-note">overall winner · &lt;$0.0001/alert</div>
     </div>
 
-    <div class="card card--slim openai">
-      <div class="card-head">
-        <div class="card-head-text">
-          <div class="card-provider">openai</div>
-          <div class="card-model">gpt-5.4</div>
-        </div>
-        <span class="card-pill card-pill--ops">
-          <svg viewBox="0 0 16 16" width="11" height="11" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="3 8 7 12 13 4"/></svg>
-          Best ops
-        </span>
+    <div class="lb-row">
+      <div>
+        <div class="lb-name">claude-opus-4-7</div>
+        <div class="lb-name-sub">anthropic</div>
       </div>
-      <div class="card-stats-dual">
-        <div class="card-stat-cell">
-          <span class="card-stat-num">0.86</span>
-          <div class="card-stat-label">verdict F1</div>
-        </div>
-        <div class="card-stat-cell">
-          <span class="card-stat-num">0.44</span>
-          <div class="card-stat-label">per-flow F1</div>
-        </div>
+      <span class="lb-lane lb-lane--frontier">Frontier LLM</span>
+      <div class="lb-metric">
+        <span class="lb-metric-num">0.93</span>
+        <div class="lb-bar"><div class="lb-bar-fill" style="width:93%; background: var(--anthropic);"></div></div>
       </div>
-      <div class="card-stat-meta">best persona: <code>threat_analyst</code></div>
+      <div class="lb-metric">
+        <span class="lb-metric-num">0.65</span>
+        <div class="lb-bar"><div class="lb-bar-fill" style="width:65%; background: var(--anthropic);"></div></div>
+      </div>
+      <div class="lb-note">best LLM · <code>soc_analyst</code></div>
+    </div>
+
+    <div class="lb-row">
+      <div>
+        <div class="lb-name">gemini-2.5-pro</div>
+        <div class="lb-name-sub">gemini</div>
+      </div>
+      <span class="lb-lane lb-lane--frontier">Frontier LLM</span>
+      <div class="lb-metric">
+        <span class="lb-metric-num">0.88</span>
+        <div class="lb-bar"><div class="lb-bar-fill" style="width:88%; background: var(--gemini);"></div></div>
+      </div>
+      <div class="lb-metric">
+        <span class="lb-metric-num">0.52</span>
+        <div class="lb-bar"><div class="lb-bar-fill" style="width:52%; background: var(--gemini);"></div></div>
+      </div>
+      <div class="lb-note">most balanced · <code>soc_analyst</code></div>
+    </div>
+
+    <div class="lb-row">
+      <div>
+        <div class="lb-name">gpt-5.4</div>
+        <div class="lb-name-sub">openai</div>
+      </div>
+      <span class="lb-lane lb-lane--frontier">Frontier LLM</span>
+      <div class="lb-metric">
+        <span class="lb-metric-num">0.86</span>
+        <div class="lb-bar"><div class="lb-bar-fill" style="width:86%; background: var(--openai);"></div></div>
+      </div>
+      <div class="lb-metric">
+        <span class="lb-metric-num">0.44</span>
+        <div class="lb-bar"><div class="lb-bar-fill" style="width:44%; background: var(--openai);"></div></div>
+      </div>
+      <div class="lb-note">best ops · <code>threat_analyst</code></div>
+    </div>
+
+    <div class="lb-row">
+      <div>
+        <div class="lb-name">foundation-sec-8b</div>
+        <div class="lb-name-sub">open weights</div>
+      </div>
+      <span class="lb-lane lb-lane--open">Open weights</span>
+      <div class="lb-metric">
+        <span class="lb-metric-num">0.75</span>
+        <div class="lb-bar"><div class="lb-bar-fill" style="width:75%; background: var(--foundation-sec);"></div></div>
+      </div>
+      <div class="lb-metric">
+        <span class="lb-metric-num">0.37</span>
+        <div class="lb-bar"><div class="lb-bar-fill" style="width:37%; background: var(--foundation-sec);"></div></div>
+      </div>
+      <div class="lb-note"><code>threat_analyst</code></div>
+    </div>
+
+    <div class="lb-row">
+      <div>
+        <div class="lb-name">seneca-qwq-32b</div>
+        <div class="lb-name-sub">open weights</div>
+      </div>
+      <span class="lb-lane lb-lane--open">Open weights</span>
+      <div class="lb-metric">
+        <span class="lb-metric-num">0.73</span>
+        <div class="lb-bar"><div class="lb-bar-fill" style="width:73%; background: var(--seneca);"></div></div>
+      </div>
+      <div class="lb-metric">
+        <span class="lb-metric-num">0.46</span>
+        <div class="lb-bar"><div class="lb-bar-fill" style="width:46%; background: var(--seneca);"></div></div>
+      </div>
+      <div class="lb-note"><code>soc_analyst</code></div>
+    </div>
+
+    <div class="lb-row">
+      <div>
+        <div class="lb-name">glm-5.2</div>
+        <div class="lb-name-sub">open weights</div>
+      </div>
+      <span class="lb-lane lb-lane--open">Open weights</span>
+      <div class="lb-metric">
+        <span class="lb-metric-num">0.48</span>
+        <div class="lb-bar"><div class="lb-bar-fill" style="width:48%; background: var(--glm);"></div></div>
+      </div>
+      <div class="lb-metric">
+        <span class="lb-metric-num">0.55</span>
+        <div class="lb-bar"><div class="lb-bar-fill" style="width:55%; background: var(--glm);"></div></div>
+      </div>
+      <div class="lb-note"><span class="lb-note-caveat">22% coverage</span><code>soc_analyst</code></div>
     </div>
   </div>
 

--- a/docs/website/index.html
+++ b/docs/website/index.html
@@ -22,7 +22,6 @@
       <a href="#overview">Overview</a>
       <a href="#detection">Detection</a>
       <a href="#methodology">Methodology</a>
-      <a href="#vs-loglm">vs LogLM</a>
     </div>
     <div class="repo-pill" role="group" aria-label="GitHub repository">
       <a class="repo-pill-half repo-pill-left" href="https://github.com/DeepTempo/socbench" target="_blank" rel="noopener" aria-label="View on GitHub">
@@ -42,6 +41,30 @@
     </div>
   </div>
 </nav>
+
+<!-- ============================================================ -->
+<!-- announcement strips                                          -->
+<!-- ============================================================ -->
+<div class="announcements">
+  <div class="announcement announcement--new">
+    <div class="announcement-inner">
+      <span class="announcement-badge announcement-badge--new">
+        <svg viewBox="0 0 16 16" width="11" height="11" fill="currentColor" aria-hidden="true"><path d="M8 0l2 6h6l-5 3.5L13 16 8 12 3 16l2-6.5L0 6h6z"/></svg>
+        NEW
+      </span>
+      <span class="announcement-text">LogLM and open-weights model results now in <a href="#detection">Detection <span aria-hidden="true">→</span></a></span>
+    </div>
+  </div>
+  <div class="announcement announcement--coming">
+    <div class="announcement-inner">
+      <span class="announcement-badge announcement-badge--coming">
+        <svg viewBox="0 0 16 16" width="11" height="11" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="5 3 12 8 5 13"/></svg>
+        COMING NEXT
+      </span>
+      <span class="announcement-text">Harness for Vulnerability Detection and Patching. <a href="#capabilities">See roadmap <span aria-hidden="true">→</span></a></span>
+    </div>
+  </div>
+</div>
 
 <!-- ============================================================ -->
 <!-- overview                                                     -->
@@ -225,7 +248,7 @@
     </div>
   </div>
 
-  <h3>Current Capabilities and Road Map</h3>
+  <h3 id="capabilities">Current Capabilities and Road Map</h3>
 
   <div class="capabilities">
     <div class="cap cap-detection live">
@@ -390,7 +413,7 @@
 
     <div class="lb-row">
       <div>
-        <div class="lb-name">foundation-sec-8b</div>
+        <div class="lb-name">sec-8b</div>
         <div class="lb-name-sub">open weights</div>
       </div>
       <span class="lb-lane lb-lane--open">Open weights</span>
@@ -440,28 +463,29 @@
     </div>
   </div>
 
-  <h3>Provider ranking: mean across 4 personas</h3>
-  <p class="section-sub">The three summary charts below are overall (across all 1,205 units). The per-flow / verdict F1 chart further down responds to the split tabs.</p>
+  <h3>Cost, reliability, and false positives</h3>
+  <p class="section-sub">Overall across all 1,205 units. LLM bars are the mean across 4 personas; LogLM is the single classifier. The per-flow / verdict F1 chart further down responds to the split tabs.</p>
 
   <div class="chart-grid">
     <div class="chart-wrap chart-wrap--grid">
       <div class="chart-title">Avg. cost per alert</div>
-      <div class="chart-sub">Total spend ÷ (1,205 units × 4 personas). One persona = one verdict = one alert.</div>
+      <div class="chart-sub">$ per verdict, log scale.</div>
       <div class="chart-canvas chart-canvas--compact"><canvas id="cost-bars"></canvas></div>
     </div>
 
     <div class="chart-wrap chart-wrap--grid">
       <div class="chart-title">FP rate</div>
-      <div class="chart-sub">Share of benign units the model wrongly called malicious.</div>
+      <div class="chart-sub">Benign units wrongly flagged malicious.</div>
       <div class="chart-canvas chart-canvas--compact"><canvas id="fpr-bars"></canvas></div>
     </div>
 
     <div class="chart-wrap chart-wrap--grid">
       <div class="chart-title">Completion rate</div>
-      <div class="chart-sub">Fraction of renderings that completed cleanly within budget.</div>
+      <div class="chart-sub">Renderings completed within budget.</div>
       <div class="chart-canvas chart-canvas--compact"><canvas id="completion-bars"></canvas></div>
     </div>
   </div>
+  <p class="chart-footnote"><code>*</code> glm-5.2 reached only 27% of the 1,205 shared units (328 of 1,205); bars use that subset and may not be representative of the model at full coverage.</p>
 
   <div class="tabs" role="tablist" aria-label="Gold-label split">
     <button class="tab active" data-split="benign"
@@ -678,7 +702,7 @@
 <section id="results">
   <div class="eyebrow">Detection · Per-persona detail</div>
   <h2>F1, cost, and reliability per persona</h2>
-  <p class="lead">All 12 (provider × persona) configurations plotted on the F1 / cost frontier, with the cross-provider winner on each dimension called out.</p>
+  <p class="lead">All 25 configurations plotted on the F1 / cost frontier: 6 LLMs × 4 personas, plus LogLM. Winners on each contract dimension called out below (LLMs only, since LogLM has no personas).</p>
   <p class="lead">At one million alerts a day, the cheapest LLM stack ($0.057 per alert) is roughly $60,000 of inference every day, before a single analyst looks at the output. At telco scale (a large telco active in the Vigil community reports approximately 70 million flow events per minute, which batches into roughly 2 billion alerts per day at 50 flows per alert), the LLM bill runs to hundreds of millions of dollars per day ($114M at the cheapest provider, ~$302M at the priciest).</p>
 
   <div class="chart-wrap">
@@ -697,8 +721,8 @@
     </div>
   </div>
 
-  <h3>Pick your persona</h3>
-  <p class="section-sub">For each contract dimension, the winning (provider × persona) configuration across all 12 combinations.</p>
+  <h3>Pick your persona · LLMs only</h3>
+  <p class="section-sub">For each contract dimension, the winning (LLM × persona) configuration across all 24 combinations. LogLM excluded here since it has no personas.</p>
   <div class="pick-cards">
     <div class="pick-card pick-card--efficacy">
       <div class="pick-card-label">
@@ -723,9 +747,9 @@
         <svg viewBox="0 0 16 16" width="12" height="12" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" aria-hidden="true"><line x1="8" y1="1" x2="8" y2="15"/><path d="M11 4H7a2 2 0 0 0 0 4h2a2 2 0 0 1 0 4H5"/></svg>
         Lowest cost
       </div>
-      <div class="pick-card-metric">$0.034</div>
-      <div class="pick-card-unit">per alert (total $41.17 / 1,205)</div>
-      <div class="pick-card-who"><strong>openai</strong> · <code>soc_analyst</code></div>
+      <div class="pick-card-metric">$0.006</div>
+      <div class="pick-card-unit">per alert (total $7.10 / 1,205)</div>
+      <div class="pick-card-who"><strong>sec-8b</strong> · <code>soc_analyst</code></div>
     </div>
 
     <div class="pick-card pick-card--reliability">
@@ -740,22 +764,9 @@
   </div>
 
   <details>
-    <summary>All 12 (provider × persona) rows</summary>
+    <summary>All 25 rows (24 LLM configurations plus LogLM)</summary>
     <div id="per-persona-table"></div>
   </details>
-</section>
-
-<!-- ============================================================ -->
-<!-- vs LogLM (placeholder)                                       -->
-<!-- ============================================================ -->
-<section id="vs-loglm">
-  <div class="eyebrow">Detection · External baseline</div>
-  <h2>vs LogLM</h2>
-  <p class="lead">Head-to-head with the trained sequence classifier on the same source datasets, with the granularity caveats spelled out.</p>
-  <div class="callout warn">
-    <div class="callout-title">Coming soon</div>
-    <p>Head-to-head comparison with LogLM lands here in a future update.</p>
-  </div>
 </section>
 
 <!-- ============================================================ -->

--- a/docs/website/js/data.js
+++ b/docs/website/js/data.js
@@ -38,28 +38,44 @@ window.SOCBenchData = {
   // §1a mean of all four personas, per split
   meanPerProvider: {
     combined: [
+      // LogLM: encoder-only foundation model. No LLM turns, so fpv (completion) is N/A.
+      // costUsd is total for the 1,205 shared units at ~$0.00004/alert.
+      { provider: "loglm", fpv: null, verdictAcc: null, verdictF1: 0.954, flowF1: 0.989, pairF1: null, hostF1: null, conf: null, costUsd: 0.20, wallMs: null, fpr: 0.02 },
       { provider: "anthropic", fpv: 0.8966, verdictAcc: 0.8426, verdictF1: 0.8812, flowF1: 0.536, pairF1: 0.5081, hostF1: 0.6663, conf: 0.7899, costUsd: 724.82, wallMs: 37539, fpr: 0.3697 },
       { provider: "gemini", fpv: 0.9386, verdictAcc: 0.7816, verdictF1: 0.8429, flowF1: 0.4061, pairF1: 0.3842, hostF1: 0.5822, conf: 0.9203, costUsd: 296.52, wallMs: 30165, fpr: 0.4928 },
       { provider: "openai", fpv: 0.9878, verdictAcc: 0.7273, verdictF1: 0.8025, flowF1: 0.3171, pairF1: 0.2975, hostF1: 0.4279, conf: 0.8632, costUsd: 272.33, wallMs: 18739, fpr: 0.5168 },
-    
+      // OSS on the 1,205 shared subset. costUsd = effective compute-inclusive cost, scaled 1205/1500 from the dump.
+      { provider: "foundation-sec", fpv: 0.7268, verdictAcc: 0.6418, verdictF1: 0.7535, flowF1: 0.3635, pairF1: 0.3629, hostF1: 0.3667, conf: null, costUsd: 61.75, wallMs: null, fpr: 0.7561 },
+      { provider: "seneca", fpv: 0.6678, verdictAcc: 0.7005, verdictF1: 0.7036, flowF1: 0.4551, pairF1: 0.4513, hostF1: 0.5335, conf: null, costUsd: 110.44, wallMs: null, fpr: 0.3818 },
+      { provider: "glm", fpv: 0.3662, verdictAcc: 0.5976, verdictF1: 0.4855, flowF1: 0.5509, pairF1: 0.5485, hostF1: 0.5837, conf: null, costUsd: 1065.22, wallMs: null, fpr: 0.4792, coverage: 0.27 },
     ],
     benign: [
+      // LogLM per-split: projected from sequence-grain metrics onto SOCBench eval-unit prior.
+      { provider: "loglm", fpv: null, verdictAcc: 0.980, verdictF1: null, flowF1: 0.980, pairF1: 0.980, hostF1: 0.980, conf: null, costUsd: 0.08, wallMs: null, fpr: 0.02 },
       { provider: "anthropic", fpv: 0.9913, verdictAcc: 0.6306, verdictF1: null, flowF1: 0.6362, pairF1: 0.6362, hostF1: 0.6362, conf: 0.6287, costUsd: 145.85, wallMs: 25399, fpr: 0.3697 },
       { provider: "gemini", fpv: 0.9814, verdictAcc: 0.5071, verdictF1: null, flowF1: 0.5671, pairF1: 0.5671, hostF1: 0.5671, conf: 0.864, costUsd: 76.05, wallMs: 24470, fpr: 0.4928 },
       { provider: "openai", fpv: 0.9885, verdictAcc: 0.4829, verdictF1: null, flowF1: 0.5061, pairF1: 0.5061, hostF1: 0.5061, conf: 0.7742, costUsd: 37.53, wallMs: 13728, fpr: 0.5168 },
-    
+      { provider: "foundation-sec", fpv: 0.7107, verdictAcc: 0.2439, verdictF1: null, flowF1: 0.9660, pairF1: 0.9660, hostF1: 0.9660, conf: null, costUsd: 23.48, wallMs: null, fpr: 0.7561 },
+      { provider: "seneca", fpv: 0.8750, verdictAcc: 0.6182, verdictF1: null, flowF1: 0.8049, pairF1: 0.8049, hostF1: 0.8049, conf: null, costUsd: 41.98, wallMs: null, fpr: 0.3818 },
+      { provider: "glm", fpv: 0.5955, verdictAcc: 0.5208, verdictF1: null, flowF1: 0.5291, pairF1: 0.5291, hostF1: 0.5291, conf: null, costUsd: 404.89, wallMs: null, fpr: 0.4792, coverage: 0.27 },
     ],
     malicious: [
+      { provider: "loglm", fpv: null, verdictAcc: 0.922, verdictF1: 0.960, flowF1: 0.989, pairF1: 0.989, hostF1: 0.989, conf: null, costUsd: 0.06, wallMs: null, fpr: null },
       { provider: "anthropic", fpv: 0.8385, verdictAcc: 0.9924, verdictF1: 0.9962, flowF1: 0.4585, pairF1: 0.4097, hostF1: 0.685, conf: 0.9076, costUsd: 578.96, wallMs: 44993, fpr: null },
       { provider: "gemini", fpv: 0.9123, verdictAcc: 0.964, verdictF1: 0.9817, flowF1: 0.3003, pairF1: 0.264, hostF1: 0.5937, conf: 0.9575, costUsd: 220.47, wallMs: 33657, fpr: null },
       { provider: "openai", fpv: 0.9873, verdictAcc: 0.8771, verdictF1: 0.9336, flowF1: 0.2008, pairF1: 0.1691, hostF1: 0.3795, conf: 0.9177, costUsd: 234.8, wallMs: 21811, fpr: null },
-    
+      { provider: "foundation-sec", fpv: 0.7340, verdictAcc: 0.8643, verdictF1: 0.9258, flowF1: 0.0103, pairF1: 0.0083, hostF1: 0.0122, conf: null, costUsd: 19.27, wallMs: null, fpr: null },
+      { provider: "seneca", fpv: 0.5485, verdictAcc: 0.7029, verdictF1: 0.8143, flowF1: 0.1611, pairF1: 0.1444, hostF1: 0.2534, conf: null, costUsd: 34.46, wallMs: null, fpr: null },
+      { provider: "glm", fpv: 0.1689, verdictAcc: 0.9750, verdictF1: 0.9868, flowF1: 0.7562, pairF1: 0.7499, hostF1: 0.8905, conf: null, costUsd: 332.35, wallMs: null, fpr: null, coverage: 0.27 },
     ],
     mixed: [
+      { provider: "loglm", fpv: null, verdictAcc: 0.922, verdictF1: 0.960, flowF1: 0.989, pairF1: 0.989, hostF1: 0.989, conf: null, costUsd: 0.06, wallMs: null, fpr: null },
       { provider: "anthropic", fpv: 0.7741, verdictAcc: 0.989, verdictF1: 0.9945, flowF1: 0.2101, pairF1: 0.2048, hostF1: 0.4535, conf: 0.9241, costUsd: 281.53, wallMs: 45479, fpr: null },
       { provider: "gemini", fpv: 0.9333, verdictAcc: 0.9683, verdictF1: 0.9838, flowF1: 0.1367, pairF1: 0.1299, hostF1: 0.5157, conf: 0.9735, costUsd: 105.04, wallMs: 34540, fpr: null },
       { provider: "openai", fpv: 0.9892, verdictAcc: 0.9442, verdictF1: 0.9711, flowF1: 0.0782, pairF1: 0.0736, hostF1: 0.2041, conf: 0.956, costUsd: 102.73, wallMs: 21559, fpr: null },
-    
+      { provider: "foundation-sec", fpv: 0.7392, verdictAcc: 0.8886, verdictF1: 0.9398, flowF1: 0.0040, pairF1: 0.0041, hostF1: 0.0123, conf: null, costUsd: 19.01, wallMs: null, fpr: null },
+      { provider: "seneca", fpv: 0.5330, verdictAcc: 0.8212, verdictF1: 0.8940, flowF1: 0.0452, pairF1: 0.0451, hostF1: 0.2940, conf: null, costUsd: 34.00, wallMs: null, fpr: null },
+      { provider: "glm", fpv: 0.1163, verdictAcc: 0.8177, verdictF1: 0.8936, flowF1: 0.5032, pairF1: 0.4913, hostF1: 0.6958, conf: null, costUsd: 327.98, wallMs: null, fpr: null, coverage: 0.27 },
     ],
   },
 
@@ -77,7 +93,21 @@ window.SOCBenchData = {
     { provider: "openai", persona: "detection_engineer", fpv: 0.9925, verdictAcc: 0.6739, verdictF1: 0.7794, flowF1: 0.2502, pairF1: 0.2276, hostF1: 0.3813, conf: 0.8966, costUsd: 84.48, p50: 15923, p95: 28890 },
     { provider: "openai", persona: "soc_analyst", fpv: 0.9784, verdictAcc: 0.7286, verdictF1: 0.8088, flowF1: 0.2979, pairF1: 0.2766, hostF1: 0.4029, conf: 0.8635, costUsd: 41.17, p50: 9150, p95: 21518 },
     { provider: "openai", persona: "threat_analyst", fpv: 0.9884, verdictAcc: 0.843, verdictF1: 0.863, flowF1: 0.4441, pairF1: 0.4263, hostF1: 0.5306, conf: 0.8425, costUsd: 81.65, p50: 14789, p95: 23904 },
-  
+    // OSS: aggregated on the 1,205 shared subset. costUsd = effective (compute-inclusive) prorated per-persona from the API-cost ratio.
+    { provider: "foundation-sec", persona: "adversary_hunter", fpv: 0.7485, verdictAcc: 0.6718, verdictF1: 0.7901, flowF1: 0.3459, pairF1: 0.3459, hostF1: 0.3459, conf: 0.9018, costUsd: 16.75, p50: 26144, p95: 138443 },
+    { provider: "foundation-sec", persona: "detection_engineer", fpv: 0.7178, verdictAcc: 0.6393, verdictF1: 0.7539, flowF1: 0.3653, pairF1: 0.3641, hostF1: 0.3676, conf: 0.8770, costUsd: 23.85, p50: 33295, p95: 154650 },
+    { provider: "foundation-sec", persona: "soc_analyst", fpv: 0.6929, verdictAcc: 0.6335, verdictF1: 0.7268, flowF1: 0.3653, pairF1: 0.3643, hostF1: 0.3737, conf: 0.8354, costUsd: 7.10, p50: 24031, p95: 74824 },
+    { provider: "foundation-sec", persona: "threat_analyst", fpv: 0.7477, verdictAcc: 0.6226, verdictF1: 0.7432, flowF1: 0.3775, pairF1: 0.3774, hostF1: 0.3796, conf: 0.8820, costUsd: 14.05, p50: 28456, p95: 165707 },
+    { provider: "seneca", persona: "adversary_hunter", fpv: 0.7710, verdictAcc: 0.7513, verdictF1: 0.7990, flowF1: 0.4038, pairF1: 0.4036, hostF1: 0.4284, conf: 0.7369, costUsd: 30.32, p50: 98613, p95: 689335 },
+    { provider: "seneca", persona: "detection_engineer", fpv: 0.7303, verdictAcc: 0.7284, verdictF1: 0.7801, flowF1: 0.4137, pairF1: 0.4123, hostF1: 0.4364, conf: 0.7706, costUsd: 31.15, p50: 104540, p95: 752779 },
+    { provider: "seneca", persona: "soc_analyst", fpv: 0.5975, verdictAcc: 0.7222, verdictF1: 0.7143, flowF1: 0.5147, pairF1: 0.5044, hostF1: 0.6736, conf: 0.7365, costUsd: 20.65, p50: 86021, p95: 331963 },
+    { provider: "seneca", persona: "threat_analyst", fpv: 0.5726, verdictAcc: 0.6000, verdictF1: 0.5208, flowF1: 0.4881, pairF1: 0.4849, hostF1: 0.5957, conf: 0.7205, costUsd: 28.32, p50: 103161, p95: 728204 },
+    { provider: "glm", persona: "adversary_hunter", fpv: 0.3427, verdictAcc: 0.6455, verdictF1: 0.4800, flowF1: 0.6093, pairF1: 0.6035, hostF1: 0.6273, conf: 0.7674, costUsd: 303.34, p50: 63989, p95: 329285 },
+    { provider: "glm", persona: "detection_engineer", fpv: 0.4299, verdictAcc: 0.6522, verdictF1: 0.5789, flowF1: 0.5442, pairF1: 0.5337, hostF1: 0.6232, conf: 0.7784, costUsd: 384.23, p50: 73105, p95: 420861 },
+    { provider: "glm", persona: "soc_analyst", fpv: 0.3578, verdictAcc: 0.7350, verdictF1: 0.5974, flowF1: 0.7106, pairF1: 0.7109, hostF1: 0.7265, conf: 0.7761, costUsd: 115.99, p50: 31015, p95: 172262 },
+    { provider: "glm", persona: "threat_analyst", fpv: 0.3344, verdictAcc: 0.3578, verdictF1: 0.2857, flowF1: 0.3396, pairF1: 0.3459, hostF1: 0.3578, conf: 0.7350, costUsd: 261.66, p50: 44065, p95: 191667 },
+    // LogLM: encoder-only, no personas. Single point on the scatter. costUsd is total on 1,205 subset.
+    { provider: "loglm", persona: null, fpv: null, verdictAcc: null, verdictF1: 0.954, flowF1: 0.989, pairF1: 0.989, hostF1: 0.989, conf: null, costUsd: 0.20, p50: null, p95: null },
   ],
 
   // §2 reliability + cost rollup per provider

--- a/docs/website/js/main.js
+++ b/docs/website/js/main.js
@@ -11,12 +11,26 @@
   const fmtUsd  = (v) => v == null ? "-" : "$" + v.toLocaleString(undefined, {minimumFractionDigits: 2, maximumFractionDigits: 2});
   const fmtSec  = (ms) => ms == null ? "-" : (ms / 1000).toFixed(1) + "s";
 
-  // Provider colors mirrored from --anthropic / --openai / --gemini in CSS.
+  // System colors mirrored from CSS variables. Frontier LLMs, LogLM, and OSS.
   const providerColor = {
-    anthropic: "#d97706", // amber-600
-    openai:    "#059669", // emerald-600
-    gemini:    "#7c3aed", // violet-600
+    anthropic:        "#d97706", // amber-600
+    openai:           "#059669", // emerald-600
+    gemini:           "#7c3aed", // violet-600
+    loglm:            "#0891b2", // cyan-600
+    "foundation-sec": "#2563eb", // blue-600
+    seneca:           "#db2777", // pink-600
+    glm:              "#65a30d", // lime-600
   };
+  // Chart x-axis labels: use the model name (not the provider). Asterisk marks partial coverage.
+  const providerLabel = (p) => ({
+    loglm:            "loglm",
+    anthropic:        "claude-opus-4-7",
+    gemini:           "gemini-2.5-pro",
+    openai:           "gpt-5.4",
+    "foundation-sec": "sec-8b",
+    seneca:           "seneca-qwq-32b",
+    glm:              "glm-5.2*",
+  }[p] || p);
 
   // ------------- nav active-section highlight on scroll -------------
   function initNavScrollspy() {
@@ -54,7 +68,7 @@
   }
   function providerBarData(rows, valueKey) {
     return {
-      labels: rows.map(r => r.provider),
+      labels: rows.map(r => providerLabel(r.provider)),
       datasets: [{
         data: rows.map(r => r[valueKey] == null ? null : r[valueKey]),
         backgroundColor: rows.map(r => providerColor[r.provider] + "cc"),
@@ -77,11 +91,15 @@
       provider: r.provider,
       value: r.costUsd / (SHARED_UNITS * PERSONAS_PER_UNIT),   // $ / alert (one persona per verdict)
     }));
-    const maxV = Math.max(...rows.map(r => r.value));
+    // Log scale so LogLM (<$0.0001) and the LLM range ($0.01 to $0.22) both read cleanly.
+    const fmtDollar = (v) => v < 0.0001 ? "<$0.0001"
+                          : v < 0.001  ? "$" + v.toFixed(4)
+                          : v < 0.01   ? "$" + v.toFixed(3)
+                          :               "$" + v.toFixed(2);
     new Chart(ctx.getContext("2d"), {
       type: "bar",
       data: {
-        labels: rows.map(r => r.provider),
+        labels: rows.map(r => providerLabel(r.provider)),
         datasets: [{
           data: rows.map(r => r.value),
           backgroundColor: rows.map(r => providerColor[r.provider] + "cc"),
@@ -89,11 +107,29 @@
           borderWidth: 1, borderRadius: 6,
         }],
       },
-      options: commonOpts({
-        yMax: Math.ceil(maxV * 1.15 * 10) / 10 || 1,
-        yFmt: (v) => "$" + v.toFixed(2),
-        tooltipFmt: (c) => `${c.label}: $${c.parsed.y.toFixed(3)} / alert`,
-      }),
+      options: {
+        responsive: true, maintainAspectRatio: false,
+        plugins: {
+          legend: { display: false },
+          tooltip: { callbacks: { label: (c) => `${c.label}: ${fmtDollar(c.parsed.y)} / alert` } },
+        },
+        scales: {
+          x: { ticks: { color: "#111827", font: { family: "ui-monospace, Menlo, monospace" } }, grid: { color: "#e5e7eb" } },
+          y: {
+            type: "logarithmic",
+            min: 0.00001, max: 1,
+            ticks: {
+              color: "#6b7280",
+              callback: (v) => {
+                // Only label the round decades so the axis stays readable.
+                const decades = [0.0001, 0.001, 0.01, 0.1, 1];
+                return decades.includes(v) ? fmtDollar(v) : "";
+              },
+            },
+            grid: { color: "#e5e7eb" },
+          },
+        },
+      },
     });
   }
 
@@ -116,28 +152,114 @@
     const ctx = document.getElementById("completion-bars");
     if (!ctx) return;
     const rows = data.meanPerProvider.combined;
+    // LogLM has no turn budget, so completion is N/A. Render as a full-height gray
+    // placeholder bar labeled "encoder-only" so the reader sees the row without
+    // implying a 100% completion rate.
+    const grayFill = "#9ca3af66", grayBorder = "#9ca3af";
+    const displayData = rows.map(r => r.provider === "loglm" ? 1.0 : r.fpv);
+    const bgColors = rows.map(r => r.provider === "loglm" ? grayFill : providerColor[r.provider] + "cc");
+    const borderColors = rows.map(r => r.provider === "loglm" ? grayBorder : providerColor[r.provider]);
+
+    const loglmLabelPlugin = {
+      id: "loglmLabel",
+      afterDatasetsDraw(chart) {
+        const ctx2 = chart.ctx;
+        const meta = chart.getDatasetMeta(0);
+        rows.forEach((r, i) => {
+          if (r.provider !== "loglm") return;
+          const bar = meta.data[i];
+          if (!bar) return;
+          ctx2.save();
+          ctx2.fillStyle = "#374151";
+          ctx2.font = "600 11px ui-monospace, Menlo, monospace";
+          ctx2.textAlign = "center";
+          ctx2.textBaseline = "middle";
+          ctx2.translate(bar.x, (bar.base + bar.y) / 2);
+          ctx2.rotate(-Math.PI / 2);
+          ctx2.fillText("encoder-only", 0, 0);
+          ctx2.restore();
+        });
+      },
+    };
+
     new Chart(ctx.getContext("2d"), {
       type: "bar",
-      data: providerBarData(rows, "fpv"),
+      data: {
+        labels: rows.map(r => providerLabel(r.provider)),
+        datasets: [{
+          data: displayData,
+          backgroundColor: bgColors,
+          borderColor: borderColors,
+          borderWidth: 1, borderRadius: 6,
+        }],
+      },
       options: commonOpts({
         yMax: 1,
         yFmt: (v) => (v * 100).toFixed(0) + "%",
-        tooltipFmt: (c) => `${c.label}: ${(c.parsed.y * 100).toFixed(1)}%`,
+        tooltipFmt: (c) => {
+          const r = rows[c.dataIndex];
+          if (r.provider === "loglm") return `${c.label}: N/A (encoder-only)`;
+          return `${c.label}: ${(c.parsed.y * 100).toFixed(1)}%`;
+        },
       }),
+      plugins: [loglmLabelPlugin],
     });
   }
 
   // ------------- headline F1 bar chart -------------
   let headlineChart = null;
+  // Plugin: draws gray "combined only" placeholder bar + rotated text for LogLM on non-combined splits.
+  const loglmSplitPlaceholder = {
+    id: "loglmSplitPlaceholder",
+    afterDatasetsDraw(chart) {
+      const rows = chart.$socbRows || [];
+      const ctx2 = chart.ctx;
+      const yScale = chart.scales.y;
+      rows.forEach((r, i) => {
+        if (r.provider !== "loglm" || r.__ghost !== true) return;
+        // Draw a full-height (y=1) gray placeholder in the space between the two datasets' bars.
+        const meta0 = chart.getDatasetMeta(0).data[i];
+        const meta1 = chart.getDatasetMeta(1).data[i];
+        if (!meta0 && !meta1) return;
+        const anyBar = meta0 || meta1;
+        const barW = (anyBar.width || 20) * 2 + 4;
+        const cx = anyBar.x;
+        const top = yScale.getPixelForValue(1);
+        const bottom = yScale.getPixelForValue(0);
+        ctx2.save();
+        ctx2.fillStyle = "#9ca3af33";
+        ctx2.strokeStyle = "#9ca3af";
+        ctx2.lineWidth = 1;
+        ctx2.beginPath();
+        ctx2.rect(cx - barW / 2, top, barW, bottom - top);
+        ctx2.fill();
+        ctx2.stroke();
+        ctx2.fillStyle = "#374151";
+        ctx2.font = "600 11px ui-monospace, Menlo, monospace";
+        ctx2.textAlign = "center";
+        ctx2.textBaseline = "middle";
+        ctx2.translate(cx, (top + bottom) / 2);
+        ctx2.rotate(-Math.PI / 2);
+        ctx2.fillText("combined only", 0, 0);
+        ctx2.restore();
+      });
+    },
+  };
+
   function renderHeadlineChart(split) {
     const ctx = document.getElementById("headline-chart");
     if (!ctx) return;
-    const rows = data.meanPerProvider[split];
+    // On non-combined splits, LogLM is missing from data.js. Prepend a ghost row so the
+    // slot is reserved and the placeholder plugin can draw a gray "combined only" bar.
+    let rows = data.meanPerProvider[split];
+    if (split !== "combined" && !rows.some(r => r.provider === "loglm")) {
+      rows = [{ provider: "loglm", flowF1: null, verdictF1: null, __ghost: true }, ...rows];
+    }
 
     const cfg = {
       type: "bar",
       data: {
-        labels: rows.map(r => r.provider),
+        labels: rows.map(r => providerLabel(r.provider)),
         datasets: [
           {
             label: "per-flow F1 (macro)",
@@ -161,7 +283,11 @@
           legend: { labels: { color: "#6b7280", font: { family: "ui-monospace, Menlo, monospace", size: 12 } } },
           tooltip: {
             callbacks: {
-              label: (c) => `${c.dataset.label}: ${c.parsed.y == null ? "n/a" : c.parsed.y.toFixed(3)}`,
+              label: (c) => {
+                const r = rows[c.dataIndex];
+                if (r.__ghost) return `${c.dataset.label}: combined only`;
+                return `${c.dataset.label}: ${c.parsed.y == null ? "n/a" : c.parsed.y.toFixed(3)}`;
+              },
             },
           },
         },
@@ -170,13 +296,16 @@
           y: { beginAtZero: true, max: 1, ticks: { color: "#6b7280" }, grid: { color: "#e5e7eb" } },
         },
       },
+      plugins: [loglmSplitPlaceholder],
     };
 
     if (headlineChart) {
       headlineChart.data = cfg.data;
+      headlineChart.$socbRows = rows;
       headlineChart.update();
     } else {
       headlineChart = new Chart(ctx.getContext("2d"), cfg);
+      headlineChart.$socbRows = rows;
     }
     renderHeadlineTable(split);
   }
@@ -185,12 +314,15 @@
   function renderHeadlineTable(split) {
     const host = document.getElementById("headline-table");
     if (!host) return;
-    const rows = data.meanPerProvider[split];
+    let rows = data.meanPerProvider[split];
+    if (split !== "combined" && !rows.some(r => r.provider === "loglm")) {
+      rows = [{ provider: "loglm", __ghost: true }, ...rows];
+    }
     host.innerHTML = `
       <table>
         <thead>
           <tr>
-            <th>Provider</th>
+            <th>System</th>
             <th class="num">Completion</th>
             <th class="num">Verdict acc</th>
             <th class="num">Verdict F1</th>
@@ -202,9 +334,15 @@
           </tr>
         </thead>
         <tbody>
-          ${rows.map(r => `
-            <tr>
-              <td class="provider-cell">${r.provider}</td>
+          ${rows.map(r => {
+            if (r.__ghost) {
+              return `<tr class="row-ghost">
+                <td class="provider-cell">${providerLabel(r.provider)}</td>
+                <td class="num" colspan="8">combined only</td>
+              </tr>`;
+            }
+            return `<tr>
+              <td class="provider-cell">${providerLabel(r.provider)}</td>
               <td class="num">${fmtPct(r.fpv)}</td>
               <td class="num">${fmtF1(r.verdictAcc)}</td>
               <td class="num">${fmtF1(r.verdictF1)}</td>
@@ -213,7 +351,8 @@
               <td class="num">${fmtF1(r.hostF1)}</td>
               <td class="num">${fmtUsd(r.costUsd)}</td>
               <td class="num">${fmtSec(r.wallMs)}</td>
-            </tr>`).join("")}
+            </tr>`;
+          }).join("")}
         </tbody>
       </table>`;
   }
@@ -259,19 +398,22 @@
     if (costScatterChart) { costScatterChart.destroy(); costScatterChart = null; }
     const field   = metric === "flow" ? "flowF1" : "verdictF1";
     const yLabel  = metric === "flow" ? "per-flow F1" : "verdict F1";
-    const yRange  = metric === "flow" ? { beginAtZero: true, max: 0.8 } : { min: 0.7, max: 1.0 };
+    // Extend to 1.0 on both metrics since LogLM sits above 0.95.
+    const yRange  = metric === "flow" ? { beginAtZero: true, max: 1.0 } : { min: 0.2, max: 1.0 };
     const points = data.perPersona.map(r => ({
       x: r.costUsd / SHARED_UNITS, y: r[field], provider: r.provider, persona: r.persona,
     }));
+    const SCATTER_SYSTEMS = ["loglm", "anthropic", "openai", "gemini", "foundation-sec", "seneca", "glm"];
     costScatterChart = new Chart(ctx.getContext("2d"), {
       type: "scatter",
       data: {
-        datasets: ["anthropic", "openai", "gemini"].map(p => {
+        datasets: SCATTER_SYSTEMS.map(p => {
           const pts = points.filter(d => d.provider === p);
-          const styles = pts.map(d => PERSONA_SHAPE[d.persona] || "circle");
-          const radii  = pts.map(d => 7 + (PERSONA_RADIUS_BUMP[PERSONA_SHAPE[d.persona]] || 0));
+          // LogLM has no persona; use a star. Others use persona shape.
+          const styles = pts.map(d => d.provider === "loglm" ? "star" : (PERSONA_SHAPE[d.persona] || "circle"));
+          const radii  = pts.map(d => d.provider === "loglm" ? 10 : 7 + (PERSONA_RADIUS_BUMP[PERSONA_SHAPE[d.persona]] || 0));
           return {
-            label: p,
+            label: providerLabel(p).replace(/\*$/, ""),
             data: pts,
             backgroundColor: providerColor[p] + "cc",
             borderColor: providerColor[p],
@@ -288,28 +430,31 @@
         plugins: {
           legend: {
             align: "center",
-            // Tighten the legend block itself (default takes a lot of vertical
-            // room). Spacing between items is now handled by `generateLabels`
-            // wrapping each label in extra whitespace.
+            // 7 systems is too many for one row. Cap width so Chart.js wraps into 2 rows.
+            maxWidth: 900,
             labels: {
               color: "#6b7280",
               font: { family: "ui-monospace, Menlo, monospace" },
               usePointStyle: true,
               pointStyle: "circle",
-              padding: 8,
+              padding: 14,
               boxWidth: 10,
               boxHeight: 10,
               generateLabels: function(chart) {
                 const defaults = Chart.defaults.plugins.legend.labels.generateLabels(chart);
-                // Pad each label text with spaces so legend items render
-                // farther apart while the legend block itself stays compact.
-                return defaults.map(l => ({ ...l, text: "    " + l.text + "    " }));
+                return defaults.map(l => ({ ...l, text: "  " + l.text + "  " }));
               },
             },
           },
           tooltip: {
             callbacks: {
-              label: (c) => `${c.raw.provider} / ${c.raw.persona}: ${yLabel}=${c.raw.y.toFixed(3)}, $${c.raw.x.toFixed(3)} / alert`,
+              label: (c) => {
+                const who = c.raw.persona ? `${providerLabel(c.raw.provider).replace(/\*$/,"")} / ${c.raw.persona}` : providerLabel(c.raw.provider).replace(/\*$/,"");
+                const costStr = c.raw.provider === "loglm" ? "<$0.0001"
+                              : c.raw.x < 0.001 ? "$" + c.raw.x.toFixed(5)
+                              : "$" + c.raw.x.toFixed(3);
+                return `${who}: ${yLabel}=${c.raw.y.toFixed(3)}, ${costStr} / alert`;
+              },
             },
           },
         },
@@ -350,8 +495,8 @@
         <tbody>
           ${data.perPersona.map(r => `
             <tr>
-              <td class="provider-cell">${r.provider}</td>
-              <td class="persona-cell">${r.persona}</td>
+              <td class="provider-cell">${providerLabel(r.provider)}</td>
+              <td class="persona-cell">${r.persona || "—"}</td>
               <td class="num">${fmtPct(r.fpv)}</td>
               <td class="num">${fmtF1(r.verdictAcc)}</td>
               <td class="num">${fmtF1(r.verdictF1)}</td>


### PR DESCRIPTION
  - Replace the 3 provider cards with a ranked leaderboard, LogLM on top
  - Add all 7 systems to summary charts (cost / FP / completion) with log-scale cost and gray "encoder-only" placeholder for LogLM completion
  - Update "Pick your persona" winners across 24 LLM configs (LLMs only)
  - Add roadmap card for Vulnerability Detection and Patching harness
  - Add top-of-page announcement strips (NEW: LogLM + open weights, COMING NEXT: vuln harness)
  - Remove the "vs LogLM" placeholder section