### PR TITLE
Add PatchLoop harness and restructure website around capabilities

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -25,15 +25,27 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - name: Copy rule against em-dashes and en-dashes
+        # Fail the build if a stray em-dash or en-dash slips into shipped copy
+        # (user rule: substitute periods / colons / hyphens / parens). Runs
+        # before cache-bust to fail early on the raw source.
+        run: |
+          if grep -rnE '—|–|&mdash;|&ndash;' $(find docs/website -name '*.html') docs/website/js/*.js; then
+            echo "::error::em-dash / en-dash found in shipped copy. Substitute periods, colons, or hyphens."
+            exit 1
+          fi
       - name: Cache-bust static assets with commit SHA
-        # Append ?v=<short-sha> to css/js references in index.html so browsers
-        # refetch on every deploy instead of serving stale files from cache.
+        # Append ?v=<short-sha> to css/js references in every deployed HTML file
+        # so browsers refetch on every deploy instead of serving stale files.
+        # Walks all HTML files recursively (root + subdirectories). Regex matches
+        # both root-relative (css/foo.css) and parent-relative (../css/foo.css)
+        # asset paths so subpages under docs/website/{slug}/ are handled too.
         run: |
           SHA=${GITHUB_SHA::12}
-          FILE=docs/website/index.html
-          sed -i "s|href=\"css/style.css\"|href=\"css/style.css?v=$SHA\"|g" "$FILE"
-          sed -i "s|src=\"js/data.js\"|src=\"js/data.js?v=$SHA\"|g" "$FILE"
-          sed -i "s|src=\"js/main.js\"|src=\"js/main.js?v=$SHA\"|g" "$FILE"
+          for FILE in $(find docs/website -name '*.html'); do
+            sed -i -E "s|(href=\"((\\.\\./)*)css/(style|harness)\\.css)\"|\\1?v=$SHA\"|g" "$FILE"
+            sed -i -E "s|(src=\"((\\.\\./)*)js/(data|main|patchloop)\\.js)\"|\\1?v=$SHA\"|g" "$FILE"
+          done
       - uses: actions/configure-pages@v5
       - uses: actions/upload-pages-artifact@v3
         with:

--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 > An open benchmark and harnesses for AI in cybersecurity operations.
 
+> [!IMPORTANT]
+> **NEW: PatchLoop.** On PatchEval (ByteDance), PatchLoop clears OpenHands, Claude Code, and SWE-agent by 20+ points: one verify-feedback round lifts strict score from 33.5% to 57.4% at ~$0.17/CVE.
+> [See the harness](src/socbench/patchloop) · [How it works](https://socbench.org/patchloop/) · [Jump to section](#patchloop-vulnerability-detection-and-patching)
+
 **What you can't measure, you can't improve. What you can't measure, you also
 can't validate.** AI in cybersecurity operations is outpacing both: vendors
 ship new agents faster than anyone can compare them on telemetry that

--- a/README.md
+++ b/README.md
@@ -142,6 +142,20 @@ dataset so it needs no committed data) and plots per-persona F1.
 results by stratum, persona, and provider. Install with
 `pip install -e ".[notebooks]"`.
 
+## PatchLoop
+
+[`src/socbench/patchloop`](src/socbench/patchloop) contains PatchLoop, a
+TypeScript verification-loop remediation harness. It proposes a patch, verifies
+it with the detector or reproduction that raised the finding, and feeds failures
+into a bounded repair attempt. PatchLoop uses Node 20+ and has its own npm
+dependencies and test suite:
+
+```bash
+cd src/socbench/patchloop
+npm install
+npm test
+```
+
 ## Extending the benchmark
 
 Every interface designed to evolve is a registry or a YAML key:

--- a/README.md
+++ b/README.md
@@ -1,19 +1,69 @@
-# socbench
+# SOCBench
 
-> Benchmark frontier reasoning LLMs as **SOC agents** on raw NetFlow data.
+> An open benchmark and harnesses for AI in cybersecurity operations.
 
-`socbench` benchmarks frontier reasoning models as SOC agents:
+**What you can't measure, you can't improve. What you can't measure, you also
+can't validate.** AI in cybersecurity operations is outpacing both: vendors
+ship new agents faster than anyone can compare them on telemetry that
+resembles what defenders actually see.
+
+SOCBench is being built to be that benchmark: exhaustive and open, putting AI
+systems through the actual work a SOC does and scoring them on the four
+dimensions that decide whether anyone can ship them: **efficacy** (does it get
+the right answer?), **cost** (what does it take to run?), **latency** (how
+fast?), and **reliability** (well-formed output, every time, within budget).
+
+Published results, interactive charts, and methodology live at
+**[socbench.org](https://socbench.org)**. This repository contains the source
+behind them: the benchmark harnesses, sample data, scoring pipeline, and the
+website itself. SOCBench grew out of work DeepTempo does to validate and
+improve their [LogLM](https://deeptempo.ai) and the open-source AI-SOC
+[Vigil](https://github.com/Vigil-SOC/vigil). Everyone is welcome to contribute
+and to help lead the project.
+
+## Capabilities
+
+SOCBench is organized around SOC capabilities. Each capability gets its own
+harness. Two are live today; this repo hosts both.
+
+| Capability | Status | Implementation |
+|---|---|---|
+| **Detection** | **Live** | The `socbench` Python package (this repo) · [results](https://socbench.org/detection/) |
+| **Vulnerability detection & patching** | **Live** | [PatchLoop](src/socbench/patchloop), TypeScript · [results](https://socbench.org/patchloop/) |
+| Triage & escalation | Roadmap | Rank alerts, dedupe, decide what gets paged and what gets closed |
+| Investigation & DFIR | Roadmap | Multi-step reasoning over evidence; timelines, root cause |
+| Threat hunting | Roadmap | Proactive search for adversary TTPs without a triggering alert |
+| Detection engineering | Roadmap | Synthesize rules and queries, explain false positives |
+| Threat intelligence | Roadmap | IOC enrichment, actor attribution, ATT&CK mapping |
+| Response & remediation | Exploring | Playbooks, containment, comms; open question whether a clean benchmark is possible |
+
+Live = published results. Roadmap = scoped, not yet measured. Exploring = open
+question whether a clean benchmark is possible.
+
+---
+
+# Detection: the `socbench` package
+
+`socbench` benchmarks reasoning models as SOC agents:
 each model runs a bounded multi-turn agent loop against a deterministic,
 pre-indexed NetFlow corpus, with persona-scoped read-only tools, fixed dollar
 caps per investigation, and a strict final-answer JSON contract. Four personas
-(SOC Analyst, Threat Analyst, Adversary Hunter, Detection Engineer) and three
-providers (OpenAI, Anthropic, Google) share the same eval units, scoring
-lenses, and ablation surface so the headline numbers and `tools_off` /
-`playbooks_off` deltas are directly comparable.
+(SOC Analyst, Threat Analyst, Adversary Hunter, Detection Engineer) share the
+same eval units, scoring lenses, and ablation surface, so headline numbers and
+`tools_off` / `playbooks_off` deltas are directly comparable across systems.
+
+The published run compares **seven systems** on 1,205 network-flow eval units:
+three frontier LLMs (Claude Opus 4.7, GPT-5.4, Gemini 2.5 Pro), three
+open-weights models (Foundation-Sec-8B, Seneca-QwQ-32B, GLM 5.2), and LogLM,
+DeepTempo's encoder-only foundation model. LogLM leads at 0.95 verdict F1 at
+under $0.0001 per alert; Claude Opus 4.7 is the best LLM at 0.93. The full
+leaderboard, per-persona detail, and the F1/cost frontier are at
+[socbench.org/detection/](https://socbench.org/detection/).
 
 The repository is **local-first**. A laptop, three API keys, and a sample
 parquet committed to the repo are enough to reproduce a smoke under a $10
-budget.
+budget. You can also run a complete smoke with **no API keys** via the mock
+provider (see Quickstart step 3, or `notebooks/quickstart.ipynb`).
 
 ## Status
 
@@ -24,15 +74,13 @@ Alpha. The full pipeline runs end-to-end. Build-out covered:
   content-addressed indexes
 - **Step 3**: read-only tools layer with persona allowlist + sample builder
 - **Step 4**: personas, playbooks, prompt compose + forbidden-token check
-- **Step 5**: provider adapters (OpenAI / Anthropic / Gemini + always-on
-  mock) and the multi-turn agent loop with budget caps and cost/latency rollups
+- **Step 5**: provider adapters (OpenAI / Anthropic / Gemini / open-source
+  endpoints + always-on mock) and the multi-turn agent loop with budget caps
+  and cost/latency rollups
 - **Step 6**: scoring (per-flow / per-pair / per-host F1), stratified
   sampling, ablation aggregation
 - **Step 7**: quickstart + results-explorer notebooks; reproduction
   instructions in `REPRODUCE.md`
-
-You can run a complete smoke today with **no API keys** via the mock provider
-(see Quickstart step 3, or `notebooks/quickstart.ipynb`).
 
 ## Install
 
@@ -142,19 +190,61 @@ dataset so it needs no committed data) and plots per-persona F1.
 results by stratum, persona, and provider. Install with
 `pip install -e ".[notebooks]"`.
 
-## PatchLoop
+---
 
-[`src/socbench/patchloop`](src/socbench/patchloop) contains PatchLoop, a
-TypeScript verification-loop remediation harness. It proposes a patch, verifies
-it with the detector or reproduction that raised the finding, and feeds failures
-into a bounded repair attempt. PatchLoop uses Node 20+ and has its own npm
-dependencies and test suite:
+# PatchLoop: vulnerability detection and patching
+
+[`src/socbench/patchloop`](src/socbench/patchloop) implements SOCBench's
+second live capability. PatchLoop is a verification-loop remediation harness
+for security findings: **propose a patch, apply it, verify it with the same
+machinery that raised the alert, feed the verbatim failure back to the model,
+and repair on top of the patched state.** Bounded attempts, typed errors,
+fail-fast verification.
+
+The headline result, on the original
+[PatchEval](https://github.com/bytedance/PatchEval) benchmark (230 real-world
+CVEs across Go, Python, and Node.js):
+
+| Setup | Strict score | Note |
+|---|---|---|
+| No feedback | 77/230 = 33.5% | gpt-5-codex, direct-edit harness |
+| One verify-feedback round | 132/230 = 57.4% | **+25.2pp from the loop alone**, ~$0.17/CVE |
+
+That verify-feedback score clears general coding agents (OpenHands, Claude
+Code, SWE-agent, all on GPT-5) on the original leaderboard by 20+ points,
+while being roughly 10x cheaper per finding than an agent loop. The
+feedback-round number was not eligible for that leaderboard (it uses
+validation output); that is the point: in a SOC you have the detector that
+raised the alert, and using it is free alpha.
+
+> **Disclaimer.** These results are from the original PatchEval benchmark. On
+> July 24, 2026, after these runs, ByteDance released **PatchEval-Verified**
+> with revised Docker environments and a new leaderboard. The numbers above
+> predate that release and are not comparable to PatchEval-Verified. A re-run
+> against the updated version is planned.
+
+The interactive walkthrough of the loop, the harness-vs-agent comparison, and
+the full leaderboard are at
+[socbench.org/patchloop/](https://socbench.org/patchloop/).
+
+PatchLoop is a **standalone TypeScript project** (Node 20+, built on
+[Effect](https://effect.website)). It is *not* installed by `pip install -e .`
+and has no Python dependencies; it lives in this repo as the harness for this
+capability. See its [README](src/socbench/patchloop/README.md) for design,
+usage, and the verifier/router seams.
 
 ```bash
 cd src/socbench/patchloop
 npm install
-npm test
+npm test        # scripted patchers + marker verifiers, no LLM or scanners needed
+
+# run the reference example against a real checkout:
+export OPENROUTER_API_KEY=...
+npx tsx examples/remediate-cve.ts --repo /path/to/checkout \
+    --finding examples/finding-cve.json
 ```
+
+---
 
 ## Extending the benchmark
 
@@ -178,14 +268,22 @@ Every interface designed to evolve is a registry or a YAML key:
   and a matching field to `EvalUnitSummary` in `models.py`.
 - **New ablation**: extend the `Ablation` handling in `prompts.py` / `agent.py`
   and the tag list in `aggregate.py`.
+- **New capability harness**: PatchLoop's `Router` registry is where new
+  remediation harness families land (dependency bumps, IaC misconfigurations,
+  detection-rule tuning); new SOC capabilities from the roadmap arrive as
+  their own harnesses alongside detection.
 
 ## Methodology
 
-The full methodology (eval units, persona x tool matrix, agent loop, scoring,
-cost model, repair policy, sampling, ablations, run artifacts) is implemented
-across the module-level files in `src/socbench/` (each carries a focused module
-docstring).
+The full detection methodology (eval units, persona × tool matrix, agent loop,
+scoring, cost model, repair policy, sampling, ablations, run artifacts) is
+implemented across the module-level files in `src/socbench/` (each carries a
+focused module docstring). PatchLoop's loop rules are documented in its
+[README](src/socbench/patchloop/README.md) and pinned by its test suite.
+Higher-level explanations live at [socbench.org](https://socbench.org).
 
 ## License
 
-Apache-2.0. See [LICENSE](LICENSE).
+Apache-2.0 for the repository; see [LICENSE](LICENSE). PatchLoop
+(`src/socbench/patchloop`) is separately licensed under
+[MIT](src/socbench/patchloop/LICENSE).

--- a/docs/website/css/harness.css
+++ b/docs/website/css/harness.css
@@ -1,0 +1,838 @@
+/* SOCBench harness pages (vuln, and future capabilities that follow the same shape).
+   Light chrome (nav, hero, stats, rules, footer) inherits landing tokens from style.css.
+   Dark chrome (.stage, .log-panel, .turn-rail, .vs-col) is an inset that keeps the
+   original patchloop aesthetic. The interactive terminal is the payoff, so it stays dark.
+   Every accent reference uses --harness-accent (per-harness identity, set on body scope).
+   Success semantics (--good) stay green so the red-to-verified moment inside the
+   animation is visibly distinct from the harness identity color. */
+
+/* ---------- harness page container: match landing's section dimensions ---------- */
+.harness-page .page {
+  max-width: 1100px;
+  margin: 0 auto;
+  padding: 32px 24px 48px;
+}
+.harness-page .page > header {
+  margin-bottom: 32px;
+}
+.harness-page .page > header h1 {
+  font-family: var(--sans);
+  font-size: 30px;
+  font-weight: 700;
+  letter-spacing: -0.02em;
+  line-height: 1.15;
+  color: var(--fg);
+  margin: 0 0 8px;
+}
+.harness-page .page > header h1 .mono {
+  font-family: var(--mono);
+  color: var(--harness-accent);
+  font-weight: 700;
+}
+.harness-page .page > header .sub {
+  color: var(--fg-muted);
+  font-size: var(--text-title);
+  line-height: 1.5;
+  max-width: 900px;
+}
+.harness-page .page > footer {
+  margin-top: 32px;
+  padding-top: 20px;
+  border-top: 1px solid var(--border);
+  color: var(--fg-muted);
+  font-size: var(--text-small);
+}
+.harness-page .page > footer code {
+  font-family: var(--mono);
+  background: #f3f4f6;
+  padding: 1px 5px;
+  border-radius: 4px;
+  color: var(--fg);
+  font-size: var(--text-small);
+}
+
+/* .harness-context* moved to style.css as .page-context* so all sub-pages can share it. */
+
+/* ---------- harness-tabs (renamed from .tabs so it never captures a landing
+   segmented control if one is dropped inside a panel later) ---------- */
+.harness-tabs {
+  display: flex;
+  gap: 4px;
+  margin: 0 0 24px;
+  border-bottom: 1px solid var(--border);
+}
+.harness-tab {
+  background: transparent;
+  border: 1px solid transparent;
+  border-bottom: none;
+  color: var(--fg-muted);
+  font: inherit;
+  font-size: var(--text-body);
+  padding: 10px 18px;
+  border-radius: 10px 10px 0 0;
+  cursor: pointer;
+  position: relative;
+  top: 1px;
+  transition: color .15s, background .15s;
+}
+.harness-tab:hover { color: var(--fg); }
+.harness-tab.active {
+  color: var(--fg);
+  background: var(--bg-card);
+  border-color: var(--border);
+  font-weight: 600;
+}
+.harness-tab.active::after {
+  content: "";
+  position: absolute;
+  left: 0; right: 0; bottom: -1px;
+  height: 2px;
+  background: var(--bg-card);
+}
+.harness-tab .hint {
+  display: block;
+  font-size: var(--text-micro);
+  font-weight: 400;
+  color: var(--fg-dim);
+  margin-top: 2px;
+}
+.harness-tab.active .hint { color: var(--harness-accent); }
+.panel { display: none; }
+.panel.active { display: block; }
+
+/* ---------- headline stats: hero on the left, 2x2 grid of supporting on the right ---------- */
+.stats-hero {
+  display: grid;
+  grid-template-columns: 1fr 1.4fr;
+  gap: 12px;
+  margin: 0 0 24px;
+}
+.stats-support {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 10px;
+}
+.stat {
+  background: var(--bg-elev);
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  padding: 12px 16px;
+  box-shadow: var(--shadow-sm);
+  min-width: 0;
+}
+.stat .val {
+  font-size: 24px;
+  font-weight: 700;
+  letter-spacing: -0.02em;
+  color: var(--fg);
+  line-height: 1.1;
+}
+.stat .val.accent { color: var(--harness-accent); }
+.stat .val.warn { color: var(--warn); }
+.stat .val.danger { color: var(--bad); }
+.stat .lbl {
+  color: var(--fg-muted);
+  font-size: var(--text-small);
+  margin-top: 4px;
+  line-height: 1.4;
+}
+.stat--hero {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  padding: 20px 24px;
+  border-color: var(--harness-accent);
+  background: var(--harness-accent-soft);
+}
+.stat--hero .val { font-size: 44px; line-height: 1; }
+.stat--hero .lbl { font-size: var(--text-body); color: var(--fg); margin-top: 8px; font-weight: 500; }
+@media (max-width: 720px) {
+  .stats-hero { grid-template-columns: 1fr; }
+  .stats-support { grid-template-columns: 1fr; }
+}
+/* Block-within-block. Orange master container holds the hero uplift + 4 supporting tiles + PatchEval description. */
+.patcheval-block {
+  border-radius: 12px;
+  padding: 20px;
+  margin: 0 0 24px;
+}
+.patcheval-block--master {
+  background: var(--harness-accent-soft);
+  border: 1px solid var(--harness-accent);
+}
+.patcheval-block-label {
+  font-family: var(--mono);
+  font-size: var(--text-micro);
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  font-weight: 700;
+  margin-bottom: 14px;
+  color: var(--harness-accent);
+}
+.patcheval-hero-inline {
+  display: flex;
+  align-items: baseline;
+  gap: 16px;
+  margin-bottom: 20px;
+  flex-wrap: wrap;
+}
+.patcheval-hero-num {
+  font-size: 52px;
+  font-weight: 700;
+  color: var(--harness-accent);
+  letter-spacing: -0.02em;
+  line-height: 1;
+}
+.patcheval-hero-lbl {
+  font-size: var(--text-title);
+  color: var(--fg);
+  font-weight: 500;
+}
+.patcheval-supports {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 10px;
+  margin-bottom: 16px;
+}
+.patcheval-supports .stat {
+  background: #f3f4f6;
+  border-color: #e5e7eb;
+  box-shadow: none;
+  min-width: 0;
+}
+.patcheval-note {
+  font-size: var(--text-small);
+  color: var(--fg-muted);
+  margin: 0;
+  line-height: 1.55;
+  max-width: 900px;
+}
+.patcheval-note a {
+  color: var(--harness-accent);
+  border-bottom: 1px solid currentColor;
+}
+.patcheval-note a:hover { text-decoration: none; }
+@media (max-width: 900px) {
+  .patcheval-supports { grid-template-columns: repeat(2, 1fr); }
+}
+@media (max-width: 600px) {
+  .patcheval-supports { grid-template-columns: 1fr; }
+  .patcheval-hero-inline { flex-direction: column; align-items: flex-start; gap: 4px; }
+  .patcheval-hero-num { font-size: 44px; }
+}
+
+/* ---------- PatchEval leaderboard comparison (table) ---------- */
+.pev-leaderboard {
+  margin: 0 0 24px;
+}
+.pev-leaderboard-label {
+  font-family: var(--mono);
+  font-size: var(--text-micro);
+  color: var(--fg-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  font-weight: 600;
+  margin-bottom: 10px;
+}
+.pev-leaderboard .table-wrap { margin: 0; }
+.pev-table th, .pev-table td { padding: 8px 12px; }
+.pev-table th { white-space: nowrap; }
+/* Full-width table with explicit column proportions so gaps between columns
+   are uniform. All four num columns get the same width so the visual rhythm
+   is consistent across Overall, Go, Python, Node.js. */
+.pev-table {
+  table-layout: fixed;
+  width: 100%;
+}
+.pev-table th:nth-child(1), .pev-table td:nth-child(1) { width: 14%; }   /* System */
+.pev-table th:nth-child(2), .pev-table td:nth-child(2) { width: 14%; }   /* Model */
+.pev-table th:nth-child(3), .pev-table td:nth-child(3) { width: 22%; }   /* Type */
+.pev-table th:nth-child(n+4), .pev-table td:nth-child(n+4) { width: 12.5%; } /* num columns */
+.pev-table th, .pev-table td { white-space: nowrap; }
+.pev-table td:last-child, .pev-table th:last-child { padding-right: 40px; }
+.pev-table .pev-row-patchloop td { background: var(--harness-accent-soft); }
+.pev-table .pev-row-patchloop td.num strong { color: var(--harness-accent); }
+.pev-table .pev-row-patchloop-base td { background: #fff7ed; }
+.pev-table td.provider-cell a {
+  color: inherit;
+  border-bottom: 1px dashed var(--fg-dim);
+  padding-bottom: 1px;
+  transition: color .15s, border-color .15s;
+}
+.pev-table td.provider-cell a:hover {
+  color: var(--harness-accent);
+  border-bottom: 1px solid var(--harness-accent);
+  text-decoration: none;
+}
+.pev-leaderboard-footnote {
+  font-size: var(--text-small);
+  color: var(--fg-muted);
+  margin: 12px 0 0;
+  line-height: 1.5;
+  max-width: 900px;
+}
+.pev-leaderboard-footnote a {
+  color: var(--harness-accent);
+  border-bottom: 1px solid currentColor;
+}
+.pev-leaderboard-footnote a:hover { text-decoration: none; }
+
+/* ---------- controls (Play / Step / Restart / speed) ---------- */
+.controls {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  margin-bottom: 16px;
+  flex-wrap: wrap;
+}
+.controls button {
+  background: var(--bg-elev);
+  border: 1px solid var(--border);
+  color: var(--fg);
+  font: inherit;
+  font-size: var(--text-body);
+  padding: 7px 16px;
+  border-radius: 8px;
+  cursor: pointer;
+  font-weight: 500;
+  transition: border-color .15s, background .15s;
+}
+.controls button:hover { border-color: var(--harness-accent); }
+.controls button.primary {
+  background: var(--harness-accent);
+  border-color: var(--harness-accent);
+  color: white;
+  font-weight: 600;
+}
+.controls button.primary:hover { background: #c2410c; border-color: #c2410c; }
+.controls select {
+  background: var(--bg-elev);
+  border: 1px solid var(--border);
+  color: var(--fg);
+  font: inherit;
+  font-size: var(--text-small);
+  padding: 7px 10px;
+  border-radius: 8px;
+}
+.attempt-pill {
+  margin-left: auto;
+  font-family: var(--mono);
+  font-size: var(--text-small);
+  color: var(--fg-muted);
+  background: var(--bg-elev);
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  padding: 6px 14px;
+}
+.attempt-pill b { color: var(--fg); }
+
+/* ============================================================
+   DARK INSET (.stage, .log-panel, .turn-rail, .vs-col and descendants)
+   ============================================================ */
+.stage-wrap {
+  display: grid;
+  grid-template-columns: 1fr 290px;
+  gap: 16px;
+  align-items: stretch;
+}
+.stage {
+  background: #0c0f14;
+  color: #e8ecf1;
+  border: 1px solid #2a3340;
+  border-radius: 14px;
+  padding: 20px;
+  position: relative;
+  overflow: hidden;
+}
+.flow {
+  display: grid;
+  grid-template-columns: 150px 118px 1fr;
+  gap: 14px;
+  align-items: start;
+}
+.stage .node {
+  background: #1a212c;
+  border: 1px solid #2a3340;
+  border-radius: 10px;
+  padding: 12px 14px;
+  transition: border-color .25s, box-shadow .25s, background .25s;
+  color: #e8ecf1;
+}
+.stage .node h3 { font-size: var(--text-small); font-weight: 600; margin-bottom: 5px; color: #e8ecf1; }
+.stage .node p { font-size: 12px; color: #8b95a5; line-height: 1.4; margin: 0; }
+.stage .node .tag {
+  display: inline-block;
+  font-family: var(--mono);
+  font-size: 11px;
+  color: #5a6575;
+  border: 1px solid #2a3340;
+  border-radius: 5px;
+  padding: 1px 6px;
+  margin: 4px 4px 0 0;
+}
+.stage .node.active {
+  border-color: var(--harness-accent);
+  box-shadow: 0 0 0 1px var(--harness-accent), 0 0 24px rgba(234, 88, 12, 0.24);
+}
+.stage .node.failed { border-color: #f87171; box-shadow: 0 0 0 1px #f87171; }
+/* success rebind: green, NOT accent orange. This is the red-to-verified moment. */
+.stage .node.passed {
+  border-color: var(--good);
+  background: rgba(22, 163, 74, 0.18);
+}
+.stage .node.passed::after {
+  content: "\2713";
+  position: absolute;
+  top: 6px; right: 8px;
+  color: var(--good);
+  font-weight: 700;
+}
+.stage .node { position: relative; }
+
+.loop-box {
+  border: 1px dashed #2a3340;
+  border-radius: 12px;
+  padding: 14px;
+}
+.loop-title {
+  font-family: var(--mono);
+  font-size: 11px;
+  color: #5a6575;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  margin-bottom: 10px;
+}
+/* Loop row: propose | apply on the top row, verify spans full-width below.
+   Verifiers stack vertically inside verify (labels are too long for a 3-col split
+   at 1100px content width; the full-width verify node holds them cleanly). */
+.loop-row {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 10px;
+  align-items: stretch;
+}
+.loop-row > #n-verify {
+  grid-column: 1 / -1;
+}
+.verifiers {
+  display: flex;
+  flex-direction: column;
+  gap: 7px;
+  margin-top: 7px;
+}
+.verifier {
+  min-width: 0;
+}
+@media (max-width: 720px) {
+  .loop-row { grid-template-columns: 1fr; }
+}
+.verifier {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 12px;
+  background: #0c0f14;
+  border: 1px solid #2a3340;
+  border-radius: 7px;
+  padding: 6px 9px;
+  transition: border-color .25s, background .25s;
+  color: #e8ecf1;
+}
+.verifier .cost { margin-left: auto; font-family: var(--mono); font-size: 10px; color: #5a6575; }
+.verifier .dot {
+  width: 8px; height: 8px; border-radius: 50%;
+  background: #5a6575; flex: none;
+  transition: background .25s;
+}
+.verifier.running { border-color: #fbbf24; }
+.verifier.running .dot { background: #fbbf24; animation: harness-pulse 0.8s infinite alternate; }
+/* success rebind */
+.verifier.pass {
+  border-color: var(--good);
+  background: rgba(22, 163, 74, 0.18);
+}
+.verifier.pass .dot { background: var(--good); }
+.verifier.fail { border-color: #f87171; background: rgba(248, 113, 113, 0.14); }
+.verifier.fail .dot { background: #f87171; }
+.verifier.skipped { opacity: 0.4; }
+@keyframes harness-pulse { from { opacity: 0.5; } to { opacity: 1; } }
+@media (prefers-reduced-motion: reduce) {
+  .verifier.running .dot { animation: none; }
+}
+
+.feedback-arc {
+  margin-top: 14px;
+  border: 1px solid #2a3340;
+  border-radius: 9px;
+  padding: 8px 12px;
+  font-size: 12px;
+  color: #8b95a5;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  transition: border-color .3s, background .3s;
+}
+.feedback-arc.active {
+  border-color: #fbbf24;
+  background: rgba(251, 191, 36, 0.16);
+  color: #e8ecf1;
+}
+.feedback-arc .arrow { font-size: 16px; color: #fbbf24; }
+
+.outcome {
+  margin-top: 14px;
+  border-radius: 9px;
+  border: 1px solid #2a3340;
+  padding: 10px 14px;
+  font-size: var(--text-small);
+  color: #5a6575;
+  font-family: var(--mono);
+  transition: all .3s;
+}
+/* success rebind */
+.outcome.success {
+  border-color: var(--good);
+  background: rgba(22, 163, 74, 0.18);
+  color: var(--good);
+  font-weight: 600;
+}
+
+.arrow-col {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  padding-top: 28px;
+  gap: 4px;
+}
+.arrow-col .kinds { display: flex; flex-direction: column; gap: 5px; }
+.arrow-col .kind {
+  font-family: var(--mono);
+  font-size: 11px;
+  padding: 3px 7px;
+  border-radius: 5px;
+  border: 1px solid #2a3340;
+  color: #8b95a5;
+  transition: all .25s;
+}
+.arrow-col .kind.lit {
+  border-color: #60a5fa;
+  color: #60a5fa;
+  background: rgba(96, 165, 250, 0.14);
+}
+
+.log-panel {
+  background: #0c0f14;
+  color: #e8ecf1;
+  border: 1px solid #2a3340;
+  border-radius: 14px;
+  padding: 14px 16px;
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+}
+.log-panel h3 {
+  font-family: var(--mono);
+  font-size: 11px;
+  color: #5a6575;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  margin: 0 0 8px;
+  font-weight: 600;
+}
+.log {
+  font-family: var(--mono);
+  font-size: 12px;
+  line-height: 1.55;
+  overflow-y: auto;
+  flex: 1;
+  max-height: 430px;
+}
+.log div { padding: 2px 0; color: #8b95a5; animation: harness-fadein 0.3s; }
+.log .ok { color: var(--good); }
+.log .err { color: #f87171; }
+.log .wrn { color: #fbbf24; }
+.log .sys { color: #5a6575; }
+@keyframes harness-fadein { from { opacity: 0; transform: translateY(3px); } to { opacity: 1; } }
+@media (prefers-reduced-motion: reduce) {
+  .log div { animation: none; }
+}
+
+/* ---------- rules cards (light chrome). 5 rules render 3+2 in a 3-col grid. ---------- */
+.rules {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 12px;
+  margin-top: 24px;
+}
+@media (max-width: 900px) {
+  .rules { grid-template-columns: repeat(2, 1fr); }
+}
+@media (max-width: 600px) {
+  .rules { grid-template-columns: 1fr; }
+}
+.rule {
+  background: var(--bg-elev);
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  padding: 14px 16px;
+  font-size: var(--text-small);
+  line-height: 1.5;
+  color: var(--fg-muted);
+  transition: border-color .3s, background .3s;
+  box-shadow: var(--shadow-sm);
+}
+.rule b {
+  color: var(--fg);
+  display: block;
+  margin-bottom: 4px;
+  font-size: var(--text-body);
+  font-weight: 600;
+}
+.rule .n {
+  font-family: var(--mono);
+  color: var(--harness-accent);
+  margin-right: 6px;
+  font-weight: 700;
+}
+.rule.lit { border-color: var(--harness-accent); background: var(--harness-accent-soft); }
+
+/* ---------- vs. tool-calling agent (tab 2). Dark inset for both columns. ---------- */
+.contrast-lede {
+  color: var(--fg-muted);
+  font-size: var(--text-title);
+  line-height: 1.55;
+  max-width: 900px;
+  margin-bottom: 20px;
+}
+.contrast-lede b { color: var(--fg); }
+.vs-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 16px;
+  align-items: stretch;
+}
+.vs-col {
+  background: #0c0f14;
+  color: #e8ecf1;
+  border: 1px solid #2a3340;
+  border-radius: 14px;
+  padding: 18px;
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+}
+.vs-col.agent { border-color: #3a3040; }
+.vs-col.patch { border-color: rgba(22, 163, 74, 0.5); }
+.vs-head {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 10px;
+  margin-bottom: 14px;
+}
+.vs-head h3 {
+  font-size: var(--text-title);
+  font-weight: 650;
+  letter-spacing: -0.01em;
+  color: #e8ecf1;
+  margin: 0;
+}
+.vs-head .badge {
+  font-family: var(--mono);
+  font-size: 11px;
+  padding: 3px 9px;
+  border-radius: 999px;
+  border: 1px solid #2a3340;
+  color: #8b95a5;
+}
+.vs-col.agent .badge { border-color: #f87171; color: #f87171; background: rgba(248, 113, 113, 0.14); }
+.vs-col.patch .badge { border-color: var(--good); color: var(--good); background: rgba(22, 163, 74, 0.18); }
+
+.payload {
+  background: #141922;
+  border: 1px solid #2a3340;
+  border-radius: 10px;
+  padding: 11px 13px;
+  margin-bottom: 12px;
+}
+.payload .plabel {
+  font-family: var(--mono);
+  font-size: 10px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: #5a6575;
+  margin-bottom: 6px;
+}
+.payload .tokens {
+  font-family: var(--mono);
+  font-size: 12px;
+  color: #8b95a5;
+  margin-bottom: 8px;
+}
+.payload .tokens b { color: #e8ecf1; }
+.payload .tokens.fat b { color: #f87171; }
+.payload .tokens.thin b { color: var(--good); }
+
+.sys-prompt {
+  font-family: var(--mono);
+  font-size: 11px;
+  line-height: 1.5;
+  color: #5a6575;
+  max-height: 4.6em;
+  overflow: hidden;
+  position: relative;
+  mask-image: linear-gradient(180deg, #000 55%, transparent);
+}
+.sys-prompt.collapsed { max-height: 2.4em; }
+.tool-catalog { display: flex; flex-wrap: wrap; gap: 5px; }
+.tool-chip {
+  font-family: var(--mono);
+  font-size: 10px;
+  padding: 3px 7px;
+  border-radius: 5px;
+  border: 1px solid #2a3340;
+  color: #8b95a5;
+  background: #141922;
+  transition: border-color .2s, color .2s, background .2s;
+}
+.tool-chip.lit {
+  border-color: #fbbf24;
+  color: #fbbf24;
+  background: rgba(251, 191, 36, 0.16);
+}
+.tool-chip.skip { opacity: 0.35; text-decoration: line-through; }
+
+.turn-rail {
+  display: flex;
+  flex-direction: column;
+  gap: 5px;
+  flex: 1;
+  min-height: 220px;
+}
+.turn {
+  display: flex;
+  align-items: center;
+  gap: 9px;
+  font-family: var(--mono);
+  font-size: 12px;
+  padding: 6px 10px;
+  border-radius: 7px;
+  border: 1px solid #2a3340;
+  background: #0c0f14;
+  color: #5a6575;
+  transition: all .25s;
+}
+.turn .tag {
+  font-size: 10px;
+  padding: 2px 6px;
+  border-radius: 4px;
+  border: 1px solid #2a3340;
+  color: #8b95a5;
+  flex: none;
+}
+.turn .body { flex: 1; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.turn .tok { color: #5a6575; flex: none; font-size: 10px; }
+.turn.active {
+  border-color: #fbbf24;
+  color: #e8ecf1;
+  background: rgba(251, 191, 36, 0.16);
+}
+.turn.active .tag { border-color: #fbbf24; color: #fbbf24; }
+.turn.done { color: #8b95a5; }
+.turn.done .tag { color: #8b95a5; }
+/* success rebind on final agent turn */
+.turn.final {
+  border-color: var(--good);
+  background: rgba(22, 163, 74, 0.18);
+  color: var(--good);
+}
+.turn.ghost { opacity: 0.35; border-style: dashed; }
+
+.meter {
+  margin-top: 14px;
+  border-top: 1px solid #2a3340;
+  padding-top: 12px;
+}
+.meter-row {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  font-size: var(--text-small);
+  color: #8b95a5;
+  margin-bottom: 5px;
+}
+.meter-row .n {
+  font-family: var(--mono);
+  font-size: 17px;
+  font-weight: 700;
+  color: #e8ecf1;
+}
+.vs-col.agent .meter-row .n { color: #f87171; }
+.vs-col.patch .meter-row .n { color: var(--good); }
+.bar {
+  height: 8px;
+  border-radius: 4px;
+  background: #0c0f14;
+  border: 1px solid #2a3340;
+  overflow: hidden;
+}
+.bar > span {
+  display: block;
+  height: 100%;
+  width: 0%;
+  background: #f87171;
+  transition: width .35s ease;
+}
+.vs-col.patch .bar > span { background: var(--good); }
+
+.punchline {
+  margin-top: 20px;
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 12px;
+}
+.punch {
+  background: var(--bg-elev);
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  padding: 14px 16px;
+  box-shadow: var(--shadow-sm);
+}
+.punch .big {
+  font-size: 26px;
+  font-weight: 700;
+  letter-spacing: -0.02em;
+  color: var(--harness-accent);
+  margin-bottom: 4px;
+}
+.punch .big.danger { color: var(--bad); }
+.punch .big.warn { color: var(--warn); }
+.punch p { font-size: var(--text-small); color: var(--fg-muted); line-height: 1.5; margin: 0; }
+
+.skip-list {
+  margin-top: 8px;
+  display: flex;
+  flex-direction: column;
+  gap: 5px;
+}
+.skip-item {
+  font-size: var(--text-small);
+  color: var(--fg-muted);
+  display: flex;
+  gap: 7px;
+  align-items: flex-start;
+}
+.skip-item .x {
+  font-family: var(--mono);
+  color: var(--good);
+  flex: none;
+  font-weight: 700;
+}
+
+/* ---------- responsive ---------- */
+@media (max-width: 900px) {
+  .vs-grid { grid-template-columns: 1fr; }
+  .punchline { grid-template-columns: 1fr; }
+  .stage-wrap { grid-template-columns: 1fr; }
+}

--- a/docs/website/css/style.css
+++ b/docs/website/css/style.css
@@ -18,6 +18,9 @@
   --foundation-sec: #2563eb;  /* blue-600 */
   --seneca:         #db2777;  /* pink-600 */
   --glm:            #65a30d;  /* lime-600 */
+  /* Capability accent tokens. Provider tokens above must NOT double as capability accents. */
+  --cap-vulnerability:      #ea580c;  /* orange-600 · vuln-harness identity */
+  --cap-vulnerability-soft: #ffedd5;  /* orange-100 */
   --good: #16a34a;
   --warn: #d97706;
   --bad:  #dc2626;
@@ -145,6 +148,7 @@ a:hover { text-decoration: underline; }
 }
 .announcement--new    { background: #ecfeff; border-left: 3px solid var(--loglm); }
 .announcement--coming { background: #fffbeb; border-left: 3px solid var(--warn); }
+.announcement--vuln   { background: #fff7ed; border-left: 3px solid var(--cap-vulnerability); }
 .announcement-badge {
   display: inline-flex; align-items: center; gap: 5px;
   font-family: var(--mono); font-size: var(--text-micro); font-weight: 700;
@@ -154,6 +158,7 @@ a:hover { text-decoration: underline; }
 }
 .announcement-badge--new    { background: #cffafe; color: #0e7490; border-color: #a5f3fc; }
 .announcement-badge--coming { background: #fef3c7; color: #b45309; border-color: #fde68a; }
+.announcement-badge--vuln   { background: var(--cap-vulnerability-soft); color: #9a3412; border-color: #fdba74; }
 .announcement-text a {
   color: inherit; font-weight: 600;
   border-bottom: 1px solid currentColor;
@@ -162,6 +167,65 @@ a:hover { text-decoration: underline; }
 .announcement-text a:hover { text-decoration: none; color: var(--accent); border-bottom-color: var(--accent); }
 .announcement--new    .announcement-text a { color: #0e7490; }
 .announcement--coming .announcement-text a { color: #b45309; }
+.announcement--vuln   .announcement-text a { color: #9a3412; }
+
+/* Breadcrumb pill in nav ("you are here"). Uses body-scope --page-accent tokens
+   (set per-page: harness-vuln = orange, page-detection = LogLM cyan). */
+.nav-current {
+  font-family: var(--mono);
+  font-size: var(--text-micro);
+  padding: 4px 10px;
+  border-radius: 6px;
+  background: var(--page-accent-soft, var(--harness-accent-soft, #f3f4f6));
+  color: var(--page-accent, var(--harness-accent, var(--fg-muted)));
+  border: 1px solid var(--page-accent, var(--harness-accent, var(--border)));
+  white-space: nowrap;
+  letter-spacing: 0.04em;
+  font-weight: 600;
+}
+body.page-detection {
+  --page-accent:      var(--loglm);
+  --page-accent-soft: #cffafe;
+}
+
+/* Shared "you are here" context strip below the nav. Sub-pages set --page-accent
+   (harness-vuln = orange, page-detection = LogLM cyan, future pages = their own). */
+.page-context {
+  border-bottom: 1px solid var(--border);
+  background: var(--page-accent-soft, var(--harness-accent-soft, #f3f4f6));
+  border-left: 3px solid var(--page-accent, var(--harness-accent, var(--border)));
+}
+.page-context-inner {
+  max-width: 1100px; margin: 0 auto;
+  padding: 10px 24px;
+  display: flex; align-items: center; gap: 16px;
+  font-size: var(--text-small);
+  color: var(--fg);
+}
+.page-context-back {
+  font-family: var(--mono);
+  font-size: var(--text-micro);
+  font-weight: 600;
+  color: var(--page-accent, var(--harness-accent, var(--fg-muted)));
+  border-bottom: 1px solid currentColor;
+  padding-bottom: 1px;
+  white-space: nowrap;
+}
+.page-context-back:hover { text-decoration: none; }
+.page-context-crumb { color: var(--fg-muted); }
+.page-context-crumb strong { color: var(--fg); }
+@media (max-width: 720px) {
+  .repo-pill-half:first-child span { display: none; }
+  .repo-pill-count { display: none; }
+}
+
+/* Harness page body scope: sets --harness-accent aliases + --page-accent for shared components. */
+body.harness-patchloop {
+  --harness-accent:      var(--cap-vulnerability);
+  --harness-accent-soft: var(--cap-vulnerability-soft);
+  --page-accent:         var(--cap-vulnerability);
+  --page-accent-soft:    var(--cap-vulnerability-soft);
+}
 
 /* ---------- sections ---------- */
 section {
@@ -171,7 +235,8 @@ section {
 }
 section + section { border-top: 1px solid var(--border); }
 /* The first section (#overview) sits directly under the announcement strips; drop its top padding. */
-.announcements + section { padding-top: 32px; }
+.announcements + section,
+.page-context + section { padding-top: 32px; }
 
 .eyebrow {
   text-transform: uppercase;
@@ -247,6 +312,7 @@ h3 { font-size: var(--text-h3); line-height: 1.3; margin: 32px 0 12px; }
 .origin-chip {
   display: inline-flex;
   align-items: center;
+  gap: 6px;
   text-decoration: none;
   transition: opacity .15s, transform .15s;
   opacity: 0.95;
@@ -261,6 +327,13 @@ h3 { font-size: var(--text-h3); line-height: 1.3; margin: 32px 0 12px; }
   height: 36px;
   width: auto;
 }
+.origin-chip-arrow {
+  font-size: 13px;
+  color: var(--fg-dim);
+  line-height: 1;
+  transition: color .15s;
+}
+.origin-chip:hover .origin-chip-arrow { color: var(--accent); }
 .origin-body {
   flex: 1;
   margin: 0;
@@ -434,11 +507,15 @@ h3 { font-size: var(--text-h3); line-height: 1.3; margin: 32px 0 12px; }
 .cap-hunting       { --cap-accent: #0891b2; }
 .cap-engineering   { --cap-accent: #059669; }
 .cap-threatintel   { --cap-accent: #4f46e5; }
+.cap-vulnerability { --cap-accent: var(--cap-vulnerability); }
 .cap-response      { --cap-accent: #dc2626; }
 
 .cap.live      { background: #f0fdf4; border-color: #bbf7d0; }
 .cap.exploring { background: #fffbeb; border-color: #fde68a; }
 .cap.planned   { opacity: 0.95; }
+/* Vuln-live gets an orange-tinted surface so the identity stays with the accent, not the generic live-green. */
+.cap-vulnerability.live { background: #fff7ed; border-color: #fed7aa; }
+.cap-vulnerability.live .cap-badge { background: var(--cap-vulnerability-soft); color: #9a3412; }
 
 .cap-head {
   display: flex;
@@ -1115,12 +1192,79 @@ pre code { background: transparent; padding: 0; }
 }
 
 /* ---------- footer ---------- */
+/* ---------- editorial footer (shared across all pages) ---------- */
 .footer {
-  max-width: 1100px; margin: 0 auto;
-  padding: 32px 24px 48px;
   border-top: 1px solid var(--border);
-  color: var(--fg-dim); font-size: var(--text-small);
+  background: var(--bg);
+  margin-top: 40px;
+}
+.footer-inner {
+  max-width: 1100px; margin: 0 auto;
+  padding: 32px 24px 20px;
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 40px;
+  align-items: start;
+}
+.footer-copy .eyebrow { margin-bottom: 6px; }
+.footer-copy h2 {
+  font-size: 24px; line-height: 1.2;
+  font-weight: 600; letter-spacing: -0.02em;
+  margin: 0 0 8px;
+}
+.footer-copy p {
+  color: var(--fg-muted);
+  font-size: var(--text-body);
+  line-height: 1.5;
+  max-width: 620px;
+  margin: 0 0 14px;
+}
+.footer-origin {
+  display: flex; flex-direction: column;
+  align-items: flex-start; gap: 10px;
+  min-width: 0;
+}
+.footer-origin-label {
+  font-family: var(--mono);
+  font-size: var(--text-micro);
+  color: var(--fg-dim);
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  font-weight: 600;
+}
+.footer-origin-logos {
+  display: flex; flex-direction: column; gap: 12px;
+}
+.footer-origin-item {
+  display: inline-flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 4px;
+  opacity: 0.95;
+  transition: opacity .15s, transform .15s;
+}
+.footer-origin-item:hover { opacity: 1; transform: translateY(-1px); text-decoration: none; }
+.footer-origin-item img { height: 36px; width: auto; display: block; }
+.footer-origin-caption {
+  font-family: var(--mono);
+  font-size: var(--text-micro);
+  color: var(--fg-muted);
+  letter-spacing: -0.01em;
+  transition: color .15s;
+}
+.footer-origin-item:hover .footer-origin-caption { color: var(--accent); }
+.footer-bottom {
+  max-width: 1100px; margin: 0 auto;
+  padding: 14px 24px 20px;
+  border-top: 1px solid var(--border);
+  color: var(--fg-dim);
+  font-size: var(--text-small);
   display: flex; justify-content: space-between; flex-wrap: wrap; gap: 12px;
+}
+@media (max-width: 720px) {
+  .footer-inner { grid-template-columns: 1fr; gap: 32px; }
+  .footer-origin { flex-direction: row; align-items: center; }
+  .footer-origin-logos { flex-direction: row; }
 }
 
 /* ---------- responsive ---------- */

--- a/docs/website/detection/index.html
+++ b/docs/website/detection/index.html
@@ -1,0 +1,561 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Detection &middot; SOCBench</title>
+  <meta name="description" content="SOCBench Detection results. 3 frontier LLMs + 3 open-weights + LogLM scored on 1,205 network-flow evaluation units. Efficacy, cost, and reliability." />
+  <link rel="stylesheet" href="../css/style.css" />
+  <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.1/dist/chart.umd.min.js" defer></script>
+  <script src="../js/data.js" defer></script>
+  <script src="../js/main.js" defer></script>
+</head>
+<body class="page-detection">
+
+<nav class="nav">
+  <div class="nav-inner">
+    <a class="nav-brand" href="../#overview"><span class="dot"></span>SOCBench</a>
+    <div class="nav-links">
+      <a href="../#overview">Overview</a>
+      <a href="../detection/">Detection</a>
+      <a href="../patchloop/">PatchLoop</a>
+    </div>
+    <span class="nav-current" aria-current="page">Detection</span>
+    <div class="repo-pill" role="group" aria-label="GitHub repository">
+      <a class="repo-pill-half repo-pill-left" href="https://github.com/DeepTempo/socbench" target="_blank" rel="noopener" aria-label="View on GitHub">
+        <svg viewBox="0 0 24 24" width="18" height="18" fill="currentColor" aria-hidden="true">
+          <path d="M12 .5C5.65.5.5 5.65.5 12c0 5.08 3.29 9.39 7.86 10.91.58.11.79-.25.79-.55v-2.17c-3.2.7-3.88-1.37-3.88-1.37-.53-1.34-1.3-1.7-1.3-1.7-1.06-.72.08-.71.08-.71 1.17.08 1.79 1.2 1.79 1.2 1.04 1.78 2.73 1.27 3.4.97.1-.75.41-1.27.74-1.56-2.55-.29-5.24-1.28-5.24-5.7 0-1.26.45-2.29 1.19-3.1-.12-.29-.52-1.46.11-3.05 0 0 .97-.31 3.18 1.18a11 11 0 0 1 5.8 0c2.21-1.49 3.18-1.18 3.18-1.18.63 1.59.23 2.76.11 3.05.74.81 1.19 1.84 1.19 3.1 0 4.43-2.69 5.41-5.25 5.69.42.36.79 1.07.79 2.16v3.2c0 .31.21.67.8.55 4.56-1.52 7.85-5.83 7.85-10.91C23.5 5.65 18.35.5 12 .5z"/>
+        </svg>
+        <span>GitHub</span>
+      </a>
+      <span class="repo-pill-divider" aria-hidden="true"></span>
+      <a class="repo-pill-half" href="https://github.com/DeepTempo/socbench" target="_blank" rel="noopener" aria-label="Star DeepTempo/socbench on GitHub">
+        <svg viewBox="0 0 16 16" width="16" height="16" fill="currentColor" aria-hidden="true">
+          <path d="M8 .25a.75.75 0 0 1 .673.418l1.882 3.815 4.21.612a.75.75 0 0 1 .416 1.279l-3.046 2.97.719 4.192a.75.75 0 0 1-1.088.791L8 12.347l-3.766 1.98a.75.75 0 0 1-1.088-.79l.72-4.194L.818 6.374a.75.75 0 0 1 .416-1.28l4.21-.611L7.327.668A.75.75 0 0 1 8 .25z"/>
+        </svg>
+        <span>Star</span>
+        <span class="repo-pill-count" id="repo-star-count" aria-label="star count"></span>
+      </a>
+    </div>
+  </div>
+</nav>
+
+<div class="page-context">
+  <div class="page-context-inner">
+    <a class="page-context-back" href="../#capabilities">&larr; Back to capabilities</a>
+    <span class="page-context-crumb">
+      Capability: <strong>Detection</strong>. Scope: 1,205 network-flow evaluation units, 7 systems compared. Status: Live.
+    </span>
+  </div>
+</div>
+
+<section id="detection">
+  <div class="eyebrow">Capability · Live</div>
+  <h2>Detection</h2>
+  <p class="lead">The Detection benchmark scores three lanes on 1,205 evaluation units:</p>
+  <ol class="lead-lanes">
+    <li><strong>Frontier LLMs.</strong> Claude Opus 4.7, GPT-5.4, Gemini 2.5 Pro.</li>
+    <li><strong>Open weights.</strong> Foundation-Sec-8B, Seneca-QwQ-32B, GLM 5.2.</li>
+    <li><strong>Foundation model for cybersecurity.</strong> LogLM, DeepTempo's encoder-only model.</li>
+  </ol>
+  <p class="lead">
+    All LLMs run in the same <strong>detection harness</strong>: four analyst personas with <a href="#persona-tools">network-flow tools</a> submitting per-unit verdicts.
+    LogLM scores sequences directly, projected onto the eval-unit class prior.
+  </p>
+
+  <div class="leaderboard">
+    <div class="lb-row lb-row--head">
+      <div>System</div>
+      <div>Lane</div>
+      <div>Verdict F1</div>
+      <div>Per-flow F1</div>
+      <div>Note</div>
+    </div>
+
+    <div class="lb-row lb-row--winner">
+      <div>
+        <div class="lb-name">loglm</div>
+        <div class="lb-name-sub">deeptempo · projected</div>
+      </div>
+      <span class="lb-lane lb-lane--purpose">Purpose-built</span>
+      <div class="lb-metric">
+        <span class="lb-metric-num">0.95</span>
+        <div class="lb-bar"><div class="lb-bar-fill" style="width:95%; background: var(--loglm);"></div></div>
+      </div>
+      <div class="lb-metric">
+        <span class="lb-metric-num">0.99</span>
+        <div class="lb-bar"><div class="lb-bar-fill" style="width:99%; background: var(--loglm);"></div></div>
+      </div>
+      <div class="lb-note">overall winner · &lt;$0.0001/alert</div>
+    </div>
+
+    <div class="lb-row">
+      <div>
+        <div class="lb-name">claude-opus-4-7</div>
+        <div class="lb-name-sub">anthropic</div>
+      </div>
+      <span class="lb-lane lb-lane--frontier">Frontier LLM</span>
+      <div class="lb-metric">
+        <span class="lb-metric-num">0.93</span>
+        <div class="lb-bar"><div class="lb-bar-fill" style="width:93%; background: var(--anthropic);"></div></div>
+      </div>
+      <div class="lb-metric">
+        <span class="lb-metric-num">0.65</span>
+        <div class="lb-bar"><div class="lb-bar-fill" style="width:65%; background: var(--anthropic);"></div></div>
+      </div>
+      <div class="lb-note">best LLM · <code>soc_analyst</code></div>
+    </div>
+
+    <div class="lb-row">
+      <div>
+        <div class="lb-name">gemini-2.5-pro</div>
+        <div class="lb-name-sub">gemini</div>
+      </div>
+      <span class="lb-lane lb-lane--frontier">Frontier LLM</span>
+      <div class="lb-metric">
+        <span class="lb-metric-num">0.88</span>
+        <div class="lb-bar"><div class="lb-bar-fill" style="width:88%; background: var(--gemini);"></div></div>
+      </div>
+      <div class="lb-metric">
+        <span class="lb-metric-num">0.52</span>
+        <div class="lb-bar"><div class="lb-bar-fill" style="width:52%; background: var(--gemini);"></div></div>
+      </div>
+      <div class="lb-note">most balanced · <code>soc_analyst</code></div>
+    </div>
+
+    <div class="lb-row">
+      <div>
+        <div class="lb-name">gpt-5.4</div>
+        <div class="lb-name-sub">openai</div>
+      </div>
+      <span class="lb-lane lb-lane--frontier">Frontier LLM</span>
+      <div class="lb-metric">
+        <span class="lb-metric-num">0.86</span>
+        <div class="lb-bar"><div class="lb-bar-fill" style="width:86%; background: var(--openai);"></div></div>
+      </div>
+      <div class="lb-metric">
+        <span class="lb-metric-num">0.44</span>
+        <div class="lb-bar"><div class="lb-bar-fill" style="width:44%; background: var(--openai);"></div></div>
+      </div>
+      <div class="lb-note">best ops · <code>threat_analyst</code></div>
+    </div>
+
+    <div class="lb-row">
+      <div>
+        <div class="lb-name">sec-8b</div>
+        <div class="lb-name-sub">open weights</div>
+      </div>
+      <span class="lb-lane lb-lane--open">Open weights</span>
+      <div class="lb-metric">
+        <span class="lb-metric-num">0.75</span>
+        <div class="lb-bar"><div class="lb-bar-fill" style="width:75%; background: var(--foundation-sec);"></div></div>
+      </div>
+      <div class="lb-metric">
+        <span class="lb-metric-num">0.37</span>
+        <div class="lb-bar"><div class="lb-bar-fill" style="width:37%; background: var(--foundation-sec);"></div></div>
+      </div>
+      <div class="lb-note"><code>threat_analyst</code></div>
+    </div>
+
+    <div class="lb-row">
+      <div>
+        <div class="lb-name">seneca-qwq-32b</div>
+        <div class="lb-name-sub">open weights</div>
+      </div>
+      <span class="lb-lane lb-lane--open">Open weights</span>
+      <div class="lb-metric">
+        <span class="lb-metric-num">0.73</span>
+        <div class="lb-bar"><div class="lb-bar-fill" style="width:73%; background: var(--seneca);"></div></div>
+      </div>
+      <div class="lb-metric">
+        <span class="lb-metric-num">0.46</span>
+        <div class="lb-bar"><div class="lb-bar-fill" style="width:46%; background: var(--seneca);"></div></div>
+      </div>
+      <div class="lb-note"><code>soc_analyst</code></div>
+    </div>
+
+    <div class="lb-row">
+      <div>
+        <div class="lb-name">glm-5.2</div>
+        <div class="lb-name-sub">open weights</div>
+      </div>
+      <span class="lb-lane lb-lane--open">Open weights</span>
+      <div class="lb-metric">
+        <span class="lb-metric-num">0.48</span>
+        <div class="lb-bar"><div class="lb-bar-fill" style="width:48%; background: var(--glm);"></div></div>
+      </div>
+      <div class="lb-metric">
+        <span class="lb-metric-num">0.55</span>
+        <div class="lb-bar"><div class="lb-bar-fill" style="width:55%; background: var(--glm);"></div></div>
+      </div>
+      <div class="lb-note"><span class="lb-note-caveat">22% coverage</span><code>soc_analyst</code></div>
+    </div>
+  </div>
+
+  <h3>Cost, reliability, and false positives</h3>
+  <p class="section-sub">Overall across all 1,205 units. LLM bars are the mean across 4 personas; LogLM is the single classifier. The per-flow / verdict F1 chart further down responds to the split tabs.</p>
+
+  <div class="chart-grid">
+    <div class="chart-wrap chart-wrap--grid">
+      <div class="chart-title">Avg. cost per alert</div>
+      <div class="chart-sub">$ per verdict, log scale.</div>
+      <div class="chart-canvas chart-canvas--compact"><canvas id="cost-bars"></canvas></div>
+    </div>
+
+    <div class="chart-wrap chart-wrap--grid">
+      <div class="chart-title">FP rate</div>
+      <div class="chart-sub">Benign units wrongly flagged malicious.</div>
+      <div class="chart-canvas chart-canvas--compact"><canvas id="fpr-bars"></canvas></div>
+    </div>
+
+    <div class="chart-wrap chart-wrap--grid">
+      <div class="chart-title">Completion rate</div>
+      <div class="chart-sub">Renderings completed within budget.</div>
+      <div class="chart-canvas chart-canvas--compact"><canvas id="completion-bars"></canvas></div>
+    </div>
+  </div>
+  <p class="chart-footnote"><code>*</code> glm-5.2 reached only 27% of the 1,205 shared units (328 of 1,205); bars use that subset and may not be representative of the model at full coverage.</p>
+
+  <div class="tabs" role="tablist" aria-label="Gold-label split">
+    <button class="tab active" data-split="benign"
+            data-desc="benign: every flow in the evaluation unit was benign. In the chart and table below, Verdict acc is the true-negative rate (specificity).">benign</button>
+    <button class="tab" data-split="malicious"
+            data-desc="malicious: at least one flow in the evaluation unit was malicious. In the chart and table below, Verdict acc is recall (true-positive rate).">malicious</button>
+    <button class="tab" data-split="mixed"
+            data-desc="mixed: the evaluation unit contained both benign and malicious flows. In the chart and table below, Verdict acc is recall on this subset.">mixed</button>
+    <button class="tab" data-split="combined"
+            data-desc="combined: every evaluation unit, regardless of label. In the chart and table below, Verdict acc is the standard binary accuracy (tp + tn) / total.">combined</button>
+  </div>
+  <p class="tab-desc" id="tab-desc">benign: every flow in the evaluation unit was benign. In the chart and table below, Verdict acc is the true-negative rate (specificity).</p>
+
+  <div class="chart-wrap">
+    <div class="chart-title">per-flow F1 and verdict F1, by split</div>
+    <div class="chart-sub">Mean across the four personas. Hover bars for exact values; click a legend entry to toggle a series.</div>
+    <div class="chart-canvas"><canvas id="headline-chart"></canvas></div>
+  </div>
+
+  <div id="headline-table" class="table-wrap"></div>
+</section>
+
+<!-- ============================================================ -->
+<!-- methodology (placeholder, filled in next pass)               -->
+<!-- ============================================================ -->
+<section id="methodology">
+  <div class="eyebrow">Detection · How it's measured</div>
+  <h2>Methodology</h2>
+  <p class="lead">SOCBench starts with a labeled NetFlow corpus that is provided <a href="https://github.com/DeepTempo/socbench/tree/main/data" target="_blank" rel="noopener">here</a>. Similar approaches on other logs are planned. From these logs a per-provider score is calculated in seven deterministic steps, enabling easy comparisons. Four analyst personas with different tool budgets are defined and work the same evaluation units; submissions are scored against held-out gold labels.</p>
+
+  <h3>The pipeline</h3>
+  <figure class="pipeline-figure">
+    <figcaption class="pipeline-eyebrow">DETERMINISTIC  ·  CONTENT-ADDRESSED  ·  REPRODUCIBLE</figcaption>
+
+    <div class="pipeline" aria-label="SOCBench pipeline: ingest, index, units, sample, agent loop, score, aggregate">
+      <div class="pipeline-row">
+        <div class="step">
+          <span class="step-num">1</span>
+          <span class="step-icon" aria-hidden="true">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" shape-rendering="geometricPrecision">
+              <rect x="3" y="4" width="18" height="16" rx="2"/><line x1="3" y1="9" x2="21" y2="9"/><line x1="3" y1="14" x2="21" y2="14"/><line x1="9" y1="4" x2="9" y2="20"/>
+            </svg>
+          </span>
+          <span class="step-title">Ingest dataset</span>
+          <span class="step-sub">757K flow records</span>
+          <span class="step-sub2">8 sources, labeled</span>
+        </div>
+        <div class="step-arrow" aria-hidden="true">
+          <svg viewBox="0 0 36 16" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round">
+            <line x1="0" y1="8" x2="24" y2="8"/>
+            <polygon points="24,2 36,8 24,14" fill="currentColor" stroke="none"/>
+          </svg>
+        </div>
+        <div class="step">
+          <span class="step-num">2</span>
+          <span class="step-icon" aria-hidden="true">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" shape-rendering="geometricPrecision">
+              <ellipse cx="12" cy="5" rx="9" ry="3"/><path d="M3 5v6c0 1.7 4 3 9 3s9-1.3 9-3V5"/><path d="M3 11v8c0 1.7 4 3 9 3s9-1.3 9-3v-8"/>
+            </svg>
+          </span>
+          <span class="step-title">Build index</span>
+          <span class="step-sub">normalize · flow IDs</span>
+          <span class="step-sub2">deterministic hash</span>
+        </div>
+        <div class="step-arrow" aria-hidden="true">
+          <svg viewBox="0 0 36 16" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round">
+            <line x1="0" y1="8" x2="24" y2="8"/>
+            <polygon points="24,2 36,8 24,14" fill="currentColor" stroke="none"/>
+          </svg>
+        </div>
+        <div class="step">
+          <span class="step-num">3</span>
+          <span class="step-icon" aria-hidden="true">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" shape-rendering="geometricPrecision">
+              <line x1="6.5" y1="7" x2="10.5" y2="11"/><line x1="17.5" y1="7" x2="13.5" y2="11"/><line x1="6.5" y1="17" x2="10.5" y2="13"/><line x1="17.5" y1="17" x2="13.5" y2="13"/>
+              <circle cx="5"  cy="6"  r="2"/><circle cx="19" cy="6"  r="2"/><circle cx="5"  cy="18" r="2"/><circle cx="19" cy="18" r="2"/>
+              <circle cx="12" cy="12" r="2.4" fill="currentColor" stroke="none"/>
+            </svg>
+          </span>
+          <span class="step-title">Construct eval units</span>
+          <span class="step-sub">pair_timeline</span>
+          <span class="step-sub2">host_egress</span>
+        </div>
+        <div class="step-arrow" aria-hidden="true">
+          <svg viewBox="0 0 36 16" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round">
+            <line x1="0" y1="8" x2="24" y2="8"/>
+            <polygon points="24,2 36,8 24,14" fill="currentColor" stroke="none"/>
+          </svg>
+        </div>
+        <div class="step">
+          <span class="step-num">4</span>
+          <span class="step-icon" aria-hidden="true">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" shape-rendering="geometricPrecision">
+              <rect x="3" y="14" width="3.5" height="6"  rx="0.6"/><rect x="10" y="9"  width="3.5" height="11" rx="0.6"/><rect x="17" y="5"  width="3.5" height="15" rx="0.6"/>
+            </svg>
+          </span>
+          <span class="step-title">Stratified sample</span>
+          <span class="step-sub">1,205 of 17,371 units</span>
+          <span class="step-sub2">across 6 strata</span>
+        </div>
+      </div>
+
+      <div class="pipeline-bridge" aria-hidden="true">
+        <svg viewBox="0 0 16 36" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round">
+          <line x1="8" y1="0" x2="8" y2="24"/>
+          <polygon points="2,24 8,36 14,24" fill="currentColor" stroke="none"/>
+        </svg>
+      </div>
+
+      <div class="pipeline-row">
+        <div class="step step--multi">
+          <span class="step-num">5</span>
+          <span class="step-icon" aria-hidden="true">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" shape-rendering="geometricPrecision">
+              <polyline points="22 4 22 10 16 10"/><polyline points="2 20 2 14 8 14"/><path d="M3.5 9a9 9 0 0 1 14.5-3.4L22 10"/><path d="M2 14l4 4.4A9 9 0 0 0 20.5 15"/>
+            </svg>
+          </span>
+          <span class="step-title">Agent loop</span>
+          <span class="step-sub">4 personas × tools</span>
+          <span class="step-sub2">ReAct, budgeted</span>
+        </div>
+        <div class="step-arrow" aria-hidden="true">
+          <svg viewBox="0 0 36 16" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round">
+            <line x1="0" y1="8" x2="24" y2="8"/>
+            <polygon points="24,2 36,8 24,14" fill="currentColor" stroke="none"/>
+          </svg>
+        </div>
+        <div class="step step--score">
+          <span class="step-num">6</span>
+          <span class="step-icon" aria-hidden="true">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" shape-rendering="geometricPrecision">
+              <circle cx="12" cy="12" r="9"/><circle cx="12" cy="12" r="5.5"/><circle cx="12" cy="12" r="2.2" fill="currentColor" stroke="none"/>
+            </svg>
+          </span>
+          <span class="step-title">Score vs gold</span>
+          <span class="step-sub">F1 at flow / pair / host</span>
+          <span class="step-sub2">held-out labels</span>
+        </div>
+        <div class="step-arrow" aria-hidden="true">
+          <svg viewBox="0 0 36 16" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round">
+            <line x1="0" y1="8" x2="24" y2="8"/>
+            <polygon points="24,2 36,8 24,14" fill="currentColor" stroke="none"/>
+          </svg>
+        </div>
+        <div class="step step--multi">
+          <span class="step-num">7</span>
+          <span class="step-icon" aria-hidden="true">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" shape-rendering="geometricPrecision">
+              <line x1="3" y1="21" x2="21" y2="21"/><rect x="5"  y="13" width="3.5" height="8"  rx="0.6"/><rect x="11" y="8"  width="3.5" height="13" rx="0.6"/><rect x="17" y="4"  width="3.5" height="17" rx="0.6"/>
+            </svg>
+          </span>
+          <span class="step-title">Aggregate &amp; compare</span>
+          <span class="step-sub">per-provider leaderboard</span>
+          <span class="step-sub2">efficacy · reliability · cost</span>
+        </div>
+      </div>
+    </div>
+
+    <figcaption class="pipeline-caption">Same corpus + same seed = same numbers.</figcaption>
+  </figure>
+
+  <h3 id="persona-tools">Persona × tools</h3>
+  <p class="section-sub">Each persona has its own turn / tool-call / wall-clock budget and a defined toolset. Higher-tier personas inherit everything below them. The SOC analyst is the lean baseline; the detection engineer carries the full toolkit.</p>
+  <div class="table-wrap">
+    <table class="matrix">
+      <thead>
+        <tr>
+          <th>Tool</th>
+          <th class="check-col">soc_analyst</th>
+          <th class="check-col">threat_analyst</th>
+          <th class="check-col">adversary_hunter</th>
+          <th class="check-col">detection_engineer</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr><td><code>list_pairs</code></td>           <td class="check has">●</td><td class="check has">●</td><td class="check has">●</td><td class="check has">●</td></tr>
+        <tr><td><code>get_pair_timeline</code></td>    <td class="check has">●</td><td class="check has">●</td><td class="check has">●</td><td class="check has">●</td></tr>
+        <tr><td><code>get_flows</code></td>            <td class="check has">●</td><td class="check has">●</td><td class="check has">●</td><td class="check has">●</td></tr>
+        <tr><td><code>host_rollup</code></td>          <td class="check has">●</td><td class="check has">●</td><td class="check has">●</td><td class="check has">●</td></tr>
+        <tr><td><code>submit_assessment</code></td>    <td class="check has">●</td><td class="check has">●</td><td class="check has">●</td><td class="check has">●</td></tr>
+        <tr><td><code>top_destinations</code></td>     <td class="check">·</td>    <td class="check has">●</td><td class="check has">●</td><td class="check has">●</td></tr>
+        <tr><td><code>pair_stats</code></td>           <td class="check">·</td>    <td class="check has">●</td><td class="check has">●</td><td class="check has">●</td></tr>
+        <tr><td><code>port_proto_matrix</code></td>    <td class="check">·</td>    <td class="check">·</td>    <td class="check has">●</td><td class="check has">●</td></tr>
+        <tr><td><code>rarity_stats</code></td>         <td class="check">·</td>    <td class="check">·</td>    <td class="check has">●</td><td class="check has">●</td></tr>
+      </tbody>
+      <tfoot>
+        <tr>
+          <td><strong>Budget</strong> <span class="muted">(turns / calls / wall)</span></td>
+          <td class="check-col num">4 / 6 / 60s</td>
+          <td class="check-col num">8 / 12 / 120s</td>
+          <td class="check-col num">10 / 16 / 150s</td>
+          <td class="check-col num">12 / 20 / 180s</td>
+        </tr>
+      </tfoot>
+    </table>
+  </div>
+  <p class="section-sub" style="margin-top:10px;">
+    <strong>Models in this run:</strong>
+    <code>anthropic = claude-opus-4-7</code>
+    <code>gemini = gemini-2.5-pro</code>
+    <code>openai = gpt-5.4</code>.
+    OpenAI receives a <strong>1.5×</strong> persona-budget multiplier (its reasoning chains are chattier; without it, large <code>host_egress</code> units exhaust budgets before submission). Disclosed for fair comparison.
+  </p>
+
+  <div class="callout info">
+    <div class="callout-title">More detail</div>
+    <p>Blogs and docs explaining the methodology in more depth, including the corpus breakdown, eval-unit construction, scoring-lens math, run-metadata schema, and deterministic-replay tuple, are coming soon. If you look at the underlying GitHub you can see some of this explained in <code>/docs</code> and in the readme. This simple website is by design higher level.</p>
+  </div>
+</section>
+
+<!-- ============================================================ -->
+<!-- results (placeholder, best-persona + cost scatter + table)   -->
+<!-- ============================================================ -->
+<section id="results">
+  <div class="eyebrow">Detection · Per-persona detail</div>
+  <h2>F1, cost, and reliability per persona</h2>
+  <p class="lead">All 25 configurations plotted on the F1 / cost frontier: 6 LLMs × 4 personas, plus LogLM. Winners on each contract dimension called out below (LLMs only, since LogLM has no personas).</p>
+  <p class="lead">At one million alerts a day, the cheapest LLM stack ($0.057 per alert) is roughly $60,000 of inference every day, before a single analyst looks at the output. At telco scale (a large telco active in the Vigil community reports approximately 70 million flow events per minute, which batches into roughly 2 billion alerts per day at 50 flows per alert), the LLM bill runs to hundreds of millions of dollars per day ($114M at the cheapest provider, ~$302M at the priciest).</p>
+
+  <div class="chart-wrap">
+    <div class="chart-title">F1 vs cost per alert, per persona</div>
+    <div class="chart-sub">Cost is dollars per alert (one evaluation unit). Up and to the left is better. Color = provider (legend in chart). Shape = persona (legend below). Hover a point for the exact values; click a provider in the legend to toggle.</div>
+    <div class="tabs tabs--compact" role="tablist" aria-label="F1 metric">
+      <button class="tab active" data-metric="verdict">verdict F1</button>
+      <button class="tab" data-metric="flow">per-flow F1</button>
+    </div>
+    <div class="chart-canvas"><canvas id="cost-chart"></canvas></div>
+    <div class="shape-legend" aria-label="Persona shape legend">
+      <span class="shape-legend-item"><svg viewBox="0 0 12 12" aria-hidden="true"><circle cx="6" cy="6" r="4.2"/></svg> soc_analyst</span>
+      <span class="shape-legend-item"><svg viewBox="0 0 12 12" aria-hidden="true"><polygon points="6,1.5 11,10.5 1,10.5"/></svg> threat_analyst</span>
+      <span class="shape-legend-item"><svg viewBox="0 0 12 12" aria-hidden="true"><polygon points="6,1 11,6 6,11 1,6"/></svg> adversary_hunter</span>
+      <span class="shape-legend-item"><svg viewBox="0 0 12 12" aria-hidden="true"><rect x="1.8" y="1.8" width="8.4" height="8.4"/></svg> detection_engineer</span>
+    </div>
+  </div>
+
+  <h3>Pick your persona · LLMs only</h3>
+  <p class="section-sub">For each contract dimension, the winning (LLM × persona) configuration across all 24 combinations. LogLM excluded here since it has no personas.</p>
+  <div class="pick-cards">
+    <div class="pick-card pick-card--efficacy">
+      <div class="pick-card-label">
+        <svg viewBox="0 0 16 16" width="12" height="12" fill="currentColor" aria-hidden="true"><path d="M8 0l2 6h6l-5 3.5L13 16 8 12 3 16l2-6.5L0 6h6z"/></svg>
+        Best efficacy
+      </div>
+      <div class="pick-stats-dual">
+        <div class="pick-stat-cell">
+          <div class="pick-card-metric">0.93</div>
+          <div class="pick-card-unit">verdict F1</div>
+        </div>
+        <div class="pick-stat-cell">
+          <div class="pick-card-metric">0.65</div>
+          <div class="pick-card-unit">per-flow F1</div>
+        </div>
+      </div>
+      <div class="pick-card-who"><strong>anthropic</strong> · <code>soc_analyst</code></div>
+    </div>
+
+    <div class="pick-card pick-card--cost">
+      <div class="pick-card-label">
+        <svg viewBox="0 0 16 16" width="12" height="12" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" aria-hidden="true"><line x1="8" y1="1" x2="8" y2="15"/><path d="M11 4H7a2 2 0 0 0 0 4h2a2 2 0 0 1 0 4H5"/></svg>
+        Lowest cost
+      </div>
+      <div class="pick-card-metric">$0.006</div>
+      <div class="pick-card-unit">per alert (total $7.10 / 1,205)</div>
+      <div class="pick-card-who"><strong>sec-8b</strong> · <code>soc_analyst</code></div>
+    </div>
+
+    <div class="pick-card pick-card--reliability">
+      <div class="pick-card-label">
+        <svg viewBox="0 0 16 16" width="12" height="12" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="3 8 7 12 13 4"/></svg>
+        Most reliable
+      </div>
+      <div class="pick-card-metric">99.3%</div>
+      <div class="pick-card-unit">completion rate</div>
+      <div class="pick-card-who"><strong>openai</strong> · <code>detection_engineer</code></div>
+    </div>
+  </div>
+
+  <details>
+    <summary>All 25 rows (24 LLM configurations plus LogLM)</summary>
+    <div id="per-persona-table"></div>
+  </details>
+</section>
+
+<!-- ============================================================ -->
+<!-- reproduce (placeholder)                                      -->
+<!-- ============================================================ -->
+<section id="reproduce">
+  <div class="eyebrow">Detection · Provenance</div>
+  <h2>The three runs on this page</h2>
+  <p class="section-sub">Every number above traces back to one of these three runs. Full artifacts and prompts are in the repo.</p>
+  <div class="table-wrap">
+    <table>
+      <thead><tr><th>Provider</th><th>Run ID</th><th class="num">Units</th><th class="num">Renderings</th><th class="num">Cost</th></tr></thead>
+      <tbody>
+        <tr><td class="provider-cell">anthropic</td><td><code>20260604T011942Z_full_main_anthropic_4bc5181b_632cbb</code></td><td class="num">1,205</td><td class="num">4,814</td><td class="num">$724.82</td></tr>
+        <tr><td class="provider-cell">openai</td><td><code>20260604T012213Z_full_main_openai_4bc5181b_0b1f4c</code></td><td class="num">1,500</td><td class="num">6,000</td><td class="num">$328.59</td></tr>
+        <tr><td class="provider-cell">gemini</td><td><code>20260604T012407Z_full_main_gemini_4bc5181b_e4a9c6</code></td><td class="num">1,500</td><td class="num">6,000</td><td class="num">$355.13</td></tr>
+      </tbody>
+    </table>
+  </div>
+
+  <div class="callout info">
+    <div class="callout-title">Cost expectations</div>
+    <p>A full run (~1,500 units × 4 personas × 3 providers) costs roughly $1,300 to $1,500 USD in LLM spend at the pricing snapshot dates in this report. A smoke run (8 units) is under $10.</p>
+  </div>
+</section>
+
+
+<footer class="footer">
+  <div class="footer-inner">
+    <div class="footer-copy">
+      <div class="eyebrow">Run it yourself</div>
+      <h2>Reproduce</h2>
+      <p>SOCBench is open. Clone, set provider keys, run the launch entry point. Or skip the run and re-score the published artifacts directly. Everything lives in the repo.</p>
+      <a class="cta-button" href="https://github.com/DeepTempo/socbench" target="_blank" rel="noopener">
+        <svg viewBox="0 0 24 24" width="18" height="18" fill="currentColor" aria-hidden="true">
+          <path d="M12 .5C5.65.5.5 5.65.5 12c0 5.08 3.29 9.39 7.86 10.91.58.11.79-.25.79-.55v-2.17c-3.2.7-3.88-1.37-3.88-1.37-.53-1.34-1.3-1.7-1.3-1.7-1.06-.72.08-.71.08-.71 1.17.08 1.79 1.2 1.79 1.2 1.04 1.78 2.73 1.27 3.4.97.1-.75.41-1.27.74-1.56-2.55-.29-5.24-1.28-5.24-5.7 0-1.26.45-2.29 1.19-3.1-.12-.29-.52-1.46.11-3.05 0 0 .97-.31 3.18 1.18a11 11 0 0 1 5.8 0c2.21-1.49 3.18-1.18 3.18-1.18.63 1.59.23 2.76.11 3.05.74.81 1.19 1.84 1.19 3.1 0 4.43-2.69 5.41-5.25 5.69.42.36.79 1.07.79 2.16v3.2c0 .31.21.67.8.55 4.56-1.52 7.85-5.83 7.85-10.91C23.5 5.65 18.35.5 12 .5z"/>
+        </svg>
+        <span>github.com/DeepTempo/socbench</span>
+        <span class="cta-arrow" aria-hidden="true">&rarr;</span>
+      </a>
+    </div>
+    <div class="footer-origin">
+      <div class="footer-origin-label">Built with</div>
+      <div class="footer-origin-logos">
+        <a href="https://deeptempo.ai" target="_blank" rel="noopener" class="footer-origin-item" aria-label="DeepTempo">
+          <img src="../img/deeptempo-logo.png" alt="DeepTempo" />
+          <span class="footer-origin-caption">deeptempo.ai <span aria-hidden="true">&#8599;</span></span>
+        </a>
+        <a href="https://github.com/Vigil-SOC/vigil" target="_blank" rel="noopener" class="footer-origin-item" aria-label="Vigil">
+          <img src="../img/vigil-logo.png" alt="Vigil" />
+          <span class="footer-origin-caption">Vigil-SOC/vigil <span aria-hidden="true">&#8599;</span></span>
+        </a>
+      </div>
+    </div>
+  </div>
+  <div class="footer-bottom">
+    <span>SOCBench &middot; open benchmark for AI in cybersecurity operations</span>
+    <span>Apache 2.0</span>
+  </div>
+</footer>
+
+</body>
+</html>

--- a/docs/website/index.html
+++ b/docs/website/index.html
@@ -20,8 +20,8 @@
     <a class="nav-brand" href="#overview"><span class="dot"></span>SOCBench</a>
     <div class="nav-links">
       <a href="#overview">Overview</a>
-      <a href="#detection">Detection</a>
-      <a href="#methodology">Methodology</a>
+      <a href="detection/">Detection</a>
+      <a href="patchloop/">PatchLoop</a>
     </div>
     <div class="repo-pill" role="group" aria-label="GitHub repository">
       <a class="repo-pill-half repo-pill-left" href="https://github.com/DeepTempo/socbench" target="_blank" rel="noopener" aria-label="View on GitHub">
@@ -52,16 +52,16 @@
         <svg viewBox="0 0 16 16" width="11" height="11" fill="currentColor" aria-hidden="true"><path d="M8 0l2 6h6l-5 3.5L13 16 8 12 3 16l2-6.5L0 6h6z"/></svg>
         NEW
       </span>
-      <span class="announcement-text">LogLM and open-weights model results now in <a href="#detection">Detection <span aria-hidden="true">→</span></a></span>
+      <span class="announcement-text">LogLM and open-weights model results now in <a href="detection/">Detection <span aria-hidden="true">→</span></a></span>
     </div>
   </div>
-  <div class="announcement announcement--coming">
+  <div class="announcement announcement--vuln">
     <div class="announcement-inner">
-      <span class="announcement-badge announcement-badge--coming">
-        <svg viewBox="0 0 16 16" width="11" height="11" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="5 3 12 8 5 13"/></svg>
-        COMING NEXT
+      <span class="announcement-badge announcement-badge--vuln">
+        <svg viewBox="0 0 16 16" width="11" height="11" fill="currentColor" aria-hidden="true"><path d="M8 0l2 6h6l-5 3.5L13 16 8 12 3 16l2-6.5L0 6h6z"/></svg>
+        NEW
       </span>
-      <span class="announcement-text">Harness for Vulnerability Detection and Patching. <a href="#capabilities">See roadmap <span aria-hidden="true">→</span></a></span>
+      <span class="announcement-text">The vulnerability remediation harness (PatchLoop) is live. <a href="patchloop/">See it in action <span aria-hidden="true">→</span></a></span>
     </div>
   </div>
 </div>
@@ -172,9 +172,11 @@
       <div class="origin-chips">
         <a class="origin-chip" href="https://deeptempo.ai" target="_blank" rel="noopener" aria-label="DeepTempo">
           <img src="img/deeptempo-logo.png" alt="DeepTempo" class="origin-chip-logo" />
+          <span class="origin-chip-arrow" aria-hidden="true">&#8599;</span>
         </a>
         <a class="origin-chip" href="https://github.com/Vigil-SOC/vigil" target="_blank" rel="noopener" aria-label="Vigil">
           <img src="img/vigil-logo.png" alt="Vigil" class="origin-chip-logo" />
+          <span class="origin-chip-arrow" aria-hidden="true">&#8599;</span>
         </a>
       </div>
       <p class="origin-body">
@@ -257,7 +259,7 @@
         <span class="cap-badge">Live</span>
       </div>
       <div class="cap-desc">Classify flows, logs, or alerts as malicious or benign (the core work of the monitoring tier).</div>
-      <a class="cap-cta" href="#detection">See results →</a>
+      <a class="cap-cta" href="detection/">See results →</a>
     </div>
     <div class="cap cap-triage planned">
       <div class="cap-head">
@@ -294,12 +296,13 @@
       </div>
       <div class="cap-desc">IOC enrichment, threat-actor attribution, MITRE ATT&amp;CK mapping.</div>
     </div>
-    <div class="cap cap-vulnerability planned">
+    <div class="cap cap-vulnerability live">
       <div class="cap-head">
         <div class="cap-title">Vulnerability detection and patching</div>
-        <span class="cap-badge">Roadmap</span>
+        <span class="cap-badge">Live</span>
       </div>
       <div class="cap-desc">Identify exploitable vulnerabilities across assets, prioritize by risk, and propose or apply patches.</div>
+      <a class="cap-cta" href="patchloop/">See PatchLoop harness →</a>
     </div>
     <div class="cap cap-response exploring">
       <div class="cap-head">
@@ -317,495 +320,39 @@
   </p>
 </section>
 
-<!-- ============================================================ -->
-<!-- detection capability: current published results              -->
-<!-- ============================================================ -->
-<section id="detection">
-  <div class="eyebrow">Capability · Live</div>
-  <h2>Detection</h2>
-  <p class="lead">The Detection benchmark scores three lanes on 1,205 evaluation units:</p>
-  <ol class="lead-lanes">
-    <li><strong>Frontier LLMs.</strong> Claude Opus 4.7, GPT-5.4, Gemini 2.5 Pro.</li>
-    <li><strong>Open weights.</strong> Foundation-Sec-8B, Seneca-QwQ-32B, GLM 5.2.</li>
-    <li><strong>Foundation model for cybersecurity.</strong> LogLM, DeepTempo's encoder-only model.</li>
-  </ol>
-  <p class="lead">
-    All LLMs run in the same <strong>detection harness</strong>: four analyst personas with <a href="#persona-tools">network-flow tools</a> submitting per-unit verdicts.
-    LogLM scores sequences directly, projected onto the eval-unit class prior.
-  </p>
-
-  <div class="leaderboard">
-    <div class="lb-row lb-row--head">
-      <div>System</div>
-      <div>Lane</div>
-      <div>Verdict F1</div>
-      <div>Per-flow F1</div>
-      <div>Note</div>
-    </div>
-
-    <div class="lb-row lb-row--winner">
-      <div>
-        <div class="lb-name">loglm</div>
-        <div class="lb-name-sub">deeptempo · projected</div>
-      </div>
-      <span class="lb-lane lb-lane--purpose">Purpose-built</span>
-      <div class="lb-metric">
-        <span class="lb-metric-num">0.95</span>
-        <div class="lb-bar"><div class="lb-bar-fill" style="width:95%; background: var(--loglm);"></div></div>
-      </div>
-      <div class="lb-metric">
-        <span class="lb-metric-num">0.99</span>
-        <div class="lb-bar"><div class="lb-bar-fill" style="width:99%; background: var(--loglm);"></div></div>
-      </div>
-      <div class="lb-note">overall winner · &lt;$0.0001/alert</div>
-    </div>
-
-    <div class="lb-row">
-      <div>
-        <div class="lb-name">claude-opus-4-7</div>
-        <div class="lb-name-sub">anthropic</div>
-      </div>
-      <span class="lb-lane lb-lane--frontier">Frontier LLM</span>
-      <div class="lb-metric">
-        <span class="lb-metric-num">0.93</span>
-        <div class="lb-bar"><div class="lb-bar-fill" style="width:93%; background: var(--anthropic);"></div></div>
-      </div>
-      <div class="lb-metric">
-        <span class="lb-metric-num">0.65</span>
-        <div class="lb-bar"><div class="lb-bar-fill" style="width:65%; background: var(--anthropic);"></div></div>
-      </div>
-      <div class="lb-note">best LLM · <code>soc_analyst</code></div>
-    </div>
-
-    <div class="lb-row">
-      <div>
-        <div class="lb-name">gemini-2.5-pro</div>
-        <div class="lb-name-sub">gemini</div>
-      </div>
-      <span class="lb-lane lb-lane--frontier">Frontier LLM</span>
-      <div class="lb-metric">
-        <span class="lb-metric-num">0.88</span>
-        <div class="lb-bar"><div class="lb-bar-fill" style="width:88%; background: var(--gemini);"></div></div>
-      </div>
-      <div class="lb-metric">
-        <span class="lb-metric-num">0.52</span>
-        <div class="lb-bar"><div class="lb-bar-fill" style="width:52%; background: var(--gemini);"></div></div>
-      </div>
-      <div class="lb-note">most balanced · <code>soc_analyst</code></div>
-    </div>
-
-    <div class="lb-row">
-      <div>
-        <div class="lb-name">gpt-5.4</div>
-        <div class="lb-name-sub">openai</div>
-      </div>
-      <span class="lb-lane lb-lane--frontier">Frontier LLM</span>
-      <div class="lb-metric">
-        <span class="lb-metric-num">0.86</span>
-        <div class="lb-bar"><div class="lb-bar-fill" style="width:86%; background: var(--openai);"></div></div>
-      </div>
-      <div class="lb-metric">
-        <span class="lb-metric-num">0.44</span>
-        <div class="lb-bar"><div class="lb-bar-fill" style="width:44%; background: var(--openai);"></div></div>
-      </div>
-      <div class="lb-note">best ops · <code>threat_analyst</code></div>
-    </div>
-
-    <div class="lb-row">
-      <div>
-        <div class="lb-name">sec-8b</div>
-        <div class="lb-name-sub">open weights</div>
-      </div>
-      <span class="lb-lane lb-lane--open">Open weights</span>
-      <div class="lb-metric">
-        <span class="lb-metric-num">0.75</span>
-        <div class="lb-bar"><div class="lb-bar-fill" style="width:75%; background: var(--foundation-sec);"></div></div>
-      </div>
-      <div class="lb-metric">
-        <span class="lb-metric-num">0.37</span>
-        <div class="lb-bar"><div class="lb-bar-fill" style="width:37%; background: var(--foundation-sec);"></div></div>
-      </div>
-      <div class="lb-note"><code>threat_analyst</code></div>
-    </div>
-
-    <div class="lb-row">
-      <div>
-        <div class="lb-name">seneca-qwq-32b</div>
-        <div class="lb-name-sub">open weights</div>
-      </div>
-      <span class="lb-lane lb-lane--open">Open weights</span>
-      <div class="lb-metric">
-        <span class="lb-metric-num">0.73</span>
-        <div class="lb-bar"><div class="lb-bar-fill" style="width:73%; background: var(--seneca);"></div></div>
-      </div>
-      <div class="lb-metric">
-        <span class="lb-metric-num">0.46</span>
-        <div class="lb-bar"><div class="lb-bar-fill" style="width:46%; background: var(--seneca);"></div></div>
-      </div>
-      <div class="lb-note"><code>soc_analyst</code></div>
-    </div>
-
-    <div class="lb-row">
-      <div>
-        <div class="lb-name">glm-5.2</div>
-        <div class="lb-name-sub">open weights</div>
-      </div>
-      <span class="lb-lane lb-lane--open">Open weights</span>
-      <div class="lb-metric">
-        <span class="lb-metric-num">0.48</span>
-        <div class="lb-bar"><div class="lb-bar-fill" style="width:48%; background: var(--glm);"></div></div>
-      </div>
-      <div class="lb-metric">
-        <span class="lb-metric-num">0.55</span>
-        <div class="lb-bar"><div class="lb-bar-fill" style="width:55%; background: var(--glm);"></div></div>
-      </div>
-      <div class="lb-note"><span class="lb-note-caveat">22% coverage</span><code>soc_analyst</code></div>
-    </div>
-  </div>
-
-  <h3>Cost, reliability, and false positives</h3>
-  <p class="section-sub">Overall across all 1,205 units. LLM bars are the mean across 4 personas; LogLM is the single classifier. The per-flow / verdict F1 chart further down responds to the split tabs.</p>
-
-  <div class="chart-grid">
-    <div class="chart-wrap chart-wrap--grid">
-      <div class="chart-title">Avg. cost per alert</div>
-      <div class="chart-sub">$ per verdict, log scale.</div>
-      <div class="chart-canvas chart-canvas--compact"><canvas id="cost-bars"></canvas></div>
-    </div>
-
-    <div class="chart-wrap chart-wrap--grid">
-      <div class="chart-title">FP rate</div>
-      <div class="chart-sub">Benign units wrongly flagged malicious.</div>
-      <div class="chart-canvas chart-canvas--compact"><canvas id="fpr-bars"></canvas></div>
-    </div>
-
-    <div class="chart-wrap chart-wrap--grid">
-      <div class="chart-title">Completion rate</div>
-      <div class="chart-sub">Renderings completed within budget.</div>
-      <div class="chart-canvas chart-canvas--compact"><canvas id="completion-bars"></canvas></div>
-    </div>
-  </div>
-  <p class="chart-footnote"><code>*</code> glm-5.2 reached only 27% of the 1,205 shared units (328 of 1,205); bars use that subset and may not be representative of the model at full coverage.</p>
-
-  <div class="tabs" role="tablist" aria-label="Gold-label split">
-    <button class="tab active" data-split="benign"
-            data-desc="benign: every flow in the evaluation unit was benign. In the chart and table below, Verdict acc is the true-negative rate (specificity).">benign</button>
-    <button class="tab" data-split="malicious"
-            data-desc="malicious: at least one flow in the evaluation unit was malicious. In the chart and table below, Verdict acc is recall (true-positive rate).">malicious</button>
-    <button class="tab" data-split="mixed"
-            data-desc="mixed: the evaluation unit contained both benign and malicious flows. In the chart and table below, Verdict acc is recall on this subset.">mixed</button>
-    <button class="tab" data-split="combined"
-            data-desc="combined: every evaluation unit, regardless of label. In the chart and table below, Verdict acc is the standard binary accuracy (tp + tn) / total.">combined</button>
-  </div>
-  <p class="tab-desc" id="tab-desc">benign: every flow in the evaluation unit was benign. In the chart and table below, Verdict acc is the true-negative rate (specificity).</p>
-
-  <div class="chart-wrap">
-    <div class="chart-title">per-flow F1 and verdict F1, by split</div>
-    <div class="chart-sub">Mean across the four personas. Hover bars for exact values; click a legend entry to toggle a series.</div>
-    <div class="chart-canvas"><canvas id="headline-chart"></canvas></div>
-  </div>
-
-  <div id="headline-table" class="table-wrap"></div>
-</section>
-
-<!-- ============================================================ -->
-<!-- methodology (placeholder, filled in next pass)               -->
-<!-- ============================================================ -->
-<section id="methodology">
-  <div class="eyebrow">Detection · How it's measured</div>
-  <h2>Methodology</h2>
-  <p class="lead">SOCBench starts with a labeled NetFlow corpus that is provided <a href="https://github.com/DeepTempo/socbench/tree/main/data" target="_blank" rel="noopener">here</a>. Similar approaches on other logs are planned. From these logs a per-provider score is calculated in seven deterministic steps, enabling easy comparisons. Four analyst personas with different tool budgets are defined and work the same evaluation units; submissions are scored against held-out gold labels.</p>
-
-  <h3>The pipeline</h3>
-  <figure class="pipeline-figure">
-    <figcaption class="pipeline-eyebrow">DETERMINISTIC  ·  CONTENT-ADDRESSED  ·  REPRODUCIBLE</figcaption>
-
-    <div class="pipeline" aria-label="SOCBench pipeline: ingest, index, units, sample, agent loop, score, aggregate">
-      <div class="pipeline-row">
-        <div class="step">
-          <span class="step-num">1</span>
-          <span class="step-icon" aria-hidden="true">
-            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" shape-rendering="geometricPrecision">
-              <rect x="3" y="4" width="18" height="16" rx="2"/><line x1="3" y1="9" x2="21" y2="9"/><line x1="3" y1="14" x2="21" y2="14"/><line x1="9" y1="4" x2="9" y2="20"/>
-            </svg>
-          </span>
-          <span class="step-title">Ingest dataset</span>
-          <span class="step-sub">757K flow records</span>
-          <span class="step-sub2">8 sources, labeled</span>
-        </div>
-        <div class="step-arrow" aria-hidden="true">
-          <svg viewBox="0 0 36 16" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round">
-            <line x1="0" y1="8" x2="24" y2="8"/>
-            <polygon points="24,2 36,8 24,14" fill="currentColor" stroke="none"/>
-          </svg>
-        </div>
-        <div class="step">
-          <span class="step-num">2</span>
-          <span class="step-icon" aria-hidden="true">
-            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" shape-rendering="geometricPrecision">
-              <ellipse cx="12" cy="5" rx="9" ry="3"/><path d="M3 5v6c0 1.7 4 3 9 3s9-1.3 9-3V5"/><path d="M3 11v8c0 1.7 4 3 9 3s9-1.3 9-3v-8"/>
-            </svg>
-          </span>
-          <span class="step-title">Build index</span>
-          <span class="step-sub">normalize · flow IDs</span>
-          <span class="step-sub2">deterministic hash</span>
-        </div>
-        <div class="step-arrow" aria-hidden="true">
-          <svg viewBox="0 0 36 16" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round">
-            <line x1="0" y1="8" x2="24" y2="8"/>
-            <polygon points="24,2 36,8 24,14" fill="currentColor" stroke="none"/>
-          </svg>
-        </div>
-        <div class="step">
-          <span class="step-num">3</span>
-          <span class="step-icon" aria-hidden="true">
-            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" shape-rendering="geometricPrecision">
-              <line x1="6.5" y1="7" x2="10.5" y2="11"/><line x1="17.5" y1="7" x2="13.5" y2="11"/><line x1="6.5" y1="17" x2="10.5" y2="13"/><line x1="17.5" y1="17" x2="13.5" y2="13"/>
-              <circle cx="5"  cy="6"  r="2"/><circle cx="19" cy="6"  r="2"/><circle cx="5"  cy="18" r="2"/><circle cx="19" cy="18" r="2"/>
-              <circle cx="12" cy="12" r="2.4" fill="currentColor" stroke="none"/>
-            </svg>
-          </span>
-          <span class="step-title">Construct eval units</span>
-          <span class="step-sub">pair_timeline</span>
-          <span class="step-sub2">host_egress</span>
-        </div>
-        <div class="step-arrow" aria-hidden="true">
-          <svg viewBox="0 0 36 16" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round">
-            <line x1="0" y1="8" x2="24" y2="8"/>
-            <polygon points="24,2 36,8 24,14" fill="currentColor" stroke="none"/>
-          </svg>
-        </div>
-        <div class="step">
-          <span class="step-num">4</span>
-          <span class="step-icon" aria-hidden="true">
-            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" shape-rendering="geometricPrecision">
-              <rect x="3" y="14" width="3.5" height="6"  rx="0.6"/><rect x="10" y="9"  width="3.5" height="11" rx="0.6"/><rect x="17" y="5"  width="3.5" height="15" rx="0.6"/>
-            </svg>
-          </span>
-          <span class="step-title">Stratified sample</span>
-          <span class="step-sub">1,205 of 17,371 units</span>
-          <span class="step-sub2">across 6 strata</span>
-        </div>
-      </div>
-
-      <div class="pipeline-bridge" aria-hidden="true">
-        <svg viewBox="0 0 16 36" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round">
-          <line x1="8" y1="0" x2="8" y2="24"/>
-          <polygon points="2,24 8,36 14,24" fill="currentColor" stroke="none"/>
-        </svg>
-      </div>
-
-      <div class="pipeline-row">
-        <div class="step step--multi">
-          <span class="step-num">5</span>
-          <span class="step-icon" aria-hidden="true">
-            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" shape-rendering="geometricPrecision">
-              <polyline points="22 4 22 10 16 10"/><polyline points="2 20 2 14 8 14"/><path d="M3.5 9a9 9 0 0 1 14.5-3.4L22 10"/><path d="M2 14l4 4.4A9 9 0 0 0 20.5 15"/>
-            </svg>
-          </span>
-          <span class="step-title">Agent loop</span>
-          <span class="step-sub">4 personas × tools</span>
-          <span class="step-sub2">ReAct, budgeted</span>
-        </div>
-        <div class="step-arrow" aria-hidden="true">
-          <svg viewBox="0 0 36 16" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round">
-            <line x1="0" y1="8" x2="24" y2="8"/>
-            <polygon points="24,2 36,8 24,14" fill="currentColor" stroke="none"/>
-          </svg>
-        </div>
-        <div class="step step--score">
-          <span class="step-num">6</span>
-          <span class="step-icon" aria-hidden="true">
-            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" shape-rendering="geometricPrecision">
-              <circle cx="12" cy="12" r="9"/><circle cx="12" cy="12" r="5.5"/><circle cx="12" cy="12" r="2.2" fill="currentColor" stroke="none"/>
-            </svg>
-          </span>
-          <span class="step-title">Score vs gold</span>
-          <span class="step-sub">F1 at flow / pair / host</span>
-          <span class="step-sub2">held-out labels</span>
-        </div>
-        <div class="step-arrow" aria-hidden="true">
-          <svg viewBox="0 0 36 16" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round">
-            <line x1="0" y1="8" x2="24" y2="8"/>
-            <polygon points="24,2 36,8 24,14" fill="currentColor" stroke="none"/>
-          </svg>
-        </div>
-        <div class="step step--multi">
-          <span class="step-num">7</span>
-          <span class="step-icon" aria-hidden="true">
-            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" shape-rendering="geometricPrecision">
-              <line x1="3" y1="21" x2="21" y2="21"/><rect x="5"  y="13" width="3.5" height="8"  rx="0.6"/><rect x="11" y="8"  width="3.5" height="13" rx="0.6"/><rect x="17" y="4"  width="3.5" height="17" rx="0.6"/>
-            </svg>
-          </span>
-          <span class="step-title">Aggregate &amp; compare</span>
-          <span class="step-sub">per-provider leaderboard</span>
-          <span class="step-sub2">efficacy · reliability · cost</span>
-        </div>
-      </div>
-    </div>
-
-    <figcaption class="pipeline-caption">Same corpus + same seed = same numbers.</figcaption>
-  </figure>
-
-  <h3 id="persona-tools">Persona × tools</h3>
-  <p class="section-sub">Each persona has its own turn / tool-call / wall-clock budget and a defined toolset. Higher-tier personas inherit everything below them. The SOC analyst is the lean baseline; the detection engineer carries the full toolkit.</p>
-  <div class="table-wrap">
-    <table class="matrix">
-      <thead>
-        <tr>
-          <th>Tool</th>
-          <th class="check-col">soc_analyst</th>
-          <th class="check-col">threat_analyst</th>
-          <th class="check-col">adversary_hunter</th>
-          <th class="check-col">detection_engineer</th>
-        </tr>
-      </thead>
-      <tbody>
-        <tr><td><code>list_pairs</code></td>           <td class="check has">●</td><td class="check has">●</td><td class="check has">●</td><td class="check has">●</td></tr>
-        <tr><td><code>get_pair_timeline</code></td>    <td class="check has">●</td><td class="check has">●</td><td class="check has">●</td><td class="check has">●</td></tr>
-        <tr><td><code>get_flows</code></td>            <td class="check has">●</td><td class="check has">●</td><td class="check has">●</td><td class="check has">●</td></tr>
-        <tr><td><code>host_rollup</code></td>          <td class="check has">●</td><td class="check has">●</td><td class="check has">●</td><td class="check has">●</td></tr>
-        <tr><td><code>submit_assessment</code></td>    <td class="check has">●</td><td class="check has">●</td><td class="check has">●</td><td class="check has">●</td></tr>
-        <tr><td><code>top_destinations</code></td>     <td class="check">·</td>    <td class="check has">●</td><td class="check has">●</td><td class="check has">●</td></tr>
-        <tr><td><code>pair_stats</code></td>           <td class="check">·</td>    <td class="check has">●</td><td class="check has">●</td><td class="check has">●</td></tr>
-        <tr><td><code>port_proto_matrix</code></td>    <td class="check">·</td>    <td class="check">·</td>    <td class="check has">●</td><td class="check has">●</td></tr>
-        <tr><td><code>rarity_stats</code></td>         <td class="check">·</td>    <td class="check">·</td>    <td class="check has">●</td><td class="check has">●</td></tr>
-      </tbody>
-      <tfoot>
-        <tr>
-          <td><strong>Budget</strong> <span class="muted">(turns / calls / wall)</span></td>
-          <td class="check-col num">4 / 6 / 60s</td>
-          <td class="check-col num">8 / 12 / 120s</td>
-          <td class="check-col num">10 / 16 / 150s</td>
-          <td class="check-col num">12 / 20 / 180s</td>
-        </tr>
-      </tfoot>
-    </table>
-  </div>
-  <p class="section-sub" style="margin-top:10px;">
-    <strong>Models in this run:</strong>
-    <code>anthropic = claude-opus-4-7</code>
-    <code>gemini = gemini-2.5-pro</code>
-    <code>openai = gpt-5.4</code>.
-    OpenAI receives a <strong>1.5×</strong> persona-budget multiplier (its reasoning chains are chattier; without it, large <code>host_egress</code> units exhaust budgets before submission). Disclosed for fair comparison.
-  </p>
-
-  <div class="callout info">
-    <div class="callout-title">More detail</div>
-    <p>Blogs and docs explaining the methodology in more depth, including the corpus breakdown, eval-unit construction, scoring-lens math, run-metadata schema, and deterministic-replay tuple, are coming soon. If you look at the underlying GitHub you can see some of this explained in <code>/docs</code> and in the readme. This simple website is by design higher level.</p>
-  </div>
-</section>
-
-<!-- ============================================================ -->
-<!-- results (placeholder, best-persona + cost scatter + table)   -->
-<!-- ============================================================ -->
-<section id="results">
-  <div class="eyebrow">Detection · Per-persona detail</div>
-  <h2>F1, cost, and reliability per persona</h2>
-  <p class="lead">All 25 configurations plotted on the F1 / cost frontier: 6 LLMs × 4 personas, plus LogLM. Winners on each contract dimension called out below (LLMs only, since LogLM has no personas).</p>
-  <p class="lead">At one million alerts a day, the cheapest LLM stack ($0.057 per alert) is roughly $60,000 of inference every day, before a single analyst looks at the output. At telco scale (a large telco active in the Vigil community reports approximately 70 million flow events per minute, which batches into roughly 2 billion alerts per day at 50 flows per alert), the LLM bill runs to hundreds of millions of dollars per day ($114M at the cheapest provider, ~$302M at the priciest).</p>
-
-  <div class="chart-wrap">
-    <div class="chart-title">F1 vs cost per alert, per persona</div>
-    <div class="chart-sub">Cost is dollars per alert (one evaluation unit). Up and to the left is better. Color = provider (legend in chart). Shape = persona (legend below). Hover a point for the exact values; click a provider in the legend to toggle.</div>
-    <div class="tabs tabs--compact" role="tablist" aria-label="F1 metric">
-      <button class="tab active" data-metric="verdict">verdict F1</button>
-      <button class="tab" data-metric="flow">per-flow F1</button>
-    </div>
-    <div class="chart-canvas"><canvas id="cost-chart"></canvas></div>
-    <div class="shape-legend" aria-label="Persona shape legend">
-      <span class="shape-legend-item"><svg viewBox="0 0 12 12" aria-hidden="true"><circle cx="6" cy="6" r="4.2"/></svg> soc_analyst</span>
-      <span class="shape-legend-item"><svg viewBox="0 0 12 12" aria-hidden="true"><polygon points="6,1.5 11,10.5 1,10.5"/></svg> threat_analyst</span>
-      <span class="shape-legend-item"><svg viewBox="0 0 12 12" aria-hidden="true"><polygon points="6,1 11,6 6,11 1,6"/></svg> adversary_hunter</span>
-      <span class="shape-legend-item"><svg viewBox="0 0 12 12" aria-hidden="true"><rect x="1.8" y="1.8" width="8.4" height="8.4"/></svg> detection_engineer</span>
-    </div>
-  </div>
-
-  <h3>Pick your persona · LLMs only</h3>
-  <p class="section-sub">For each contract dimension, the winning (LLM × persona) configuration across all 24 combinations. LogLM excluded here since it has no personas.</p>
-  <div class="pick-cards">
-    <div class="pick-card pick-card--efficacy">
-      <div class="pick-card-label">
-        <svg viewBox="0 0 16 16" width="12" height="12" fill="currentColor" aria-hidden="true"><path d="M8 0l2 6h6l-5 3.5L13 16 8 12 3 16l2-6.5L0 6h6z"/></svg>
-        Best efficacy
-      </div>
-      <div class="pick-stats-dual">
-        <div class="pick-stat-cell">
-          <div class="pick-card-metric">0.93</div>
-          <div class="pick-card-unit">verdict F1</div>
-        </div>
-        <div class="pick-stat-cell">
-          <div class="pick-card-metric">0.65</div>
-          <div class="pick-card-unit">per-flow F1</div>
-        </div>
-      </div>
-      <div class="pick-card-who"><strong>anthropic</strong> · <code>soc_analyst</code></div>
-    </div>
-
-    <div class="pick-card pick-card--cost">
-      <div class="pick-card-label">
-        <svg viewBox="0 0 16 16" width="12" height="12" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" aria-hidden="true"><line x1="8" y1="1" x2="8" y2="15"/><path d="M11 4H7a2 2 0 0 0 0 4h2a2 2 0 0 1 0 4H5"/></svg>
-        Lowest cost
-      </div>
-      <div class="pick-card-metric">$0.006</div>
-      <div class="pick-card-unit">per alert (total $7.10 / 1,205)</div>
-      <div class="pick-card-who"><strong>sec-8b</strong> · <code>soc_analyst</code></div>
-    </div>
-
-    <div class="pick-card pick-card--reliability">
-      <div class="pick-card-label">
-        <svg viewBox="0 0 16 16" width="12" height="12" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="3 8 7 12 13 4"/></svg>
-        Most reliable
-      </div>
-      <div class="pick-card-metric">99.3%</div>
-      <div class="pick-card-unit">completion rate</div>
-      <div class="pick-card-who"><strong>openai</strong> · <code>detection_engineer</code></div>
-    </div>
-  </div>
-
-  <details>
-    <summary>All 25 rows (24 LLM configurations plus LogLM)</summary>
-    <div id="per-persona-table"></div>
-  </details>
-</section>
-
-<!-- ============================================================ -->
-<!-- reproduce (placeholder)                                      -->
-<!-- ============================================================ -->
-<section id="reproduce">
-  <div class="eyebrow">Run it yourself</div>
-  <h2>Reproduce</h2>
-  <p class="lead">SOCBench is open. Clone, set provider keys, run the launch entry point. Or skip the run and re-score the published artifacts directly. Everything lives in the repo.</p>
-
-  <a class="cta-button" href="https://github.com/DeepTempo/socbench" target="_blank" rel="noopener">
-    <svg viewBox="0 0 24 24" width="18" height="18" fill="currentColor" aria-hidden="true">
-      <path d="M12 .5C5.65.5.5 5.65.5 12c0 5.08 3.29 9.39 7.86 10.91.58.11.79-.25.79-.55v-2.17c-3.2.7-3.88-1.37-3.88-1.37-.53-1.34-1.3-1.7-1.3-1.7-1.06-.72.08-.71.08-.71 1.17.08 1.79 1.2 1.79 1.2 1.04 1.78 2.73 1.27 3.4.97.1-.75.41-1.27.74-1.56-2.55-.29-5.24-1.28-5.24-5.7 0-1.26.45-2.29 1.19-3.1-.12-.29-.52-1.46.11-3.05 0 0 .97-.31 3.18 1.18a11 11 0 0 1 5.8 0c2.21-1.49 3.18-1.18 3.18-1.18.63 1.59.23 2.76.11 3.05.74.81 1.19 1.84 1.19 3.1 0 4.43-2.69 5.41-5.25 5.69.42.36.79 1.07.79 2.16v3.2c0 .31.21.67.8.55 4.56-1.52 7.85-5.83 7.85-10.91C23.5 5.65 18.35.5 12 .5z"/>
-    </svg>
-    <span>github.com/DeepTempo/socbench</span>
-    <span class="cta-arrow" aria-hidden="true">→</span>
-  </a>
-
-  <h3>The three runs on this page</h3>
-  <div class="table-wrap">
-    <table>
-      <thead><tr><th>Provider</th><th>Run ID</th><th class="num">Units</th><th class="num">Renderings</th><th class="num">Cost</th></tr></thead>
-      <tbody>
-        <tr><td class="provider-cell">anthropic</td><td><code>20260604T011942Z_full_main_anthropic_4bc5181b_632cbb</code></td><td class="num">1,205</td><td class="num">4,814</td><td class="num">$724.82</td></tr>
-        <tr><td class="provider-cell">openai</td><td><code>20260604T012213Z_full_main_openai_4bc5181b_0b1f4c</code></td><td class="num">1,500</td><td class="num">6,000</td><td class="num">$328.59</td></tr>
-        <tr><td class="provider-cell">gemini</td><td><code>20260604T012407Z_full_main_gemini_4bc5181b_e4a9c6</code></td><td class="num">1,500</td><td class="num">6,000</td><td class="num">$355.13</td></tr>
-      </tbody>
-    </table>
-  </div>
-
-  <div class="callout info">
-    <div class="callout-title">Cost expectations</div>
-    <p>A full run (~1,500 units × 4 personas × 3 providers) costs roughly $1,300 to $1,500 USD in LLM spend at the pricing snapshot dates in this report. A smoke run (8 units) is under $10.</p>
-  </div>
-</section>
 
 <footer class="footer">
-  <div>SOCBench</div>
-  <div><a href="https://github.com/DeepTempo/socbench">github.com/DeepTempo/socbench</a></div>
+  <div class="footer-inner">
+    <div class="footer-copy">
+      <div class="eyebrow">Run it yourself</div>
+      <h2>Reproduce</h2>
+      <p>SOCBench is open. Clone, set provider keys, run the launch entry point. Or skip the run and re-score the published artifacts directly. Everything lives in the repo.</p>
+      <a class="cta-button" href="https://github.com/DeepTempo/socbench" target="_blank" rel="noopener">
+        <svg viewBox="0 0 24 24" width="18" height="18" fill="currentColor" aria-hidden="true">
+          <path d="M12 .5C5.65.5.5 5.65.5 12c0 5.08 3.29 9.39 7.86 10.91.58.11.79-.25.79-.55v-2.17c-3.2.7-3.88-1.37-3.88-1.37-.53-1.34-1.3-1.7-1.3-1.7-1.06-.72.08-.71.08-.71 1.17.08 1.79 1.2 1.79 1.2 1.04 1.78 2.73 1.27 3.4.97.1-.75.41-1.27.74-1.56-2.55-.29-5.24-1.28-5.24-5.7 0-1.26.45-2.29 1.19-3.1-.12-.29-.52-1.46.11-3.05 0 0 .97-.31 3.18 1.18a11 11 0 0 1 5.8 0c2.21-1.49 3.18-1.18 3.18-1.18.63 1.59.23 2.76.11 3.05.74.81 1.19 1.84 1.19 3.1 0 4.43-2.69 5.41-5.25 5.69.42.36.79 1.07.79 2.16v3.2c0 .31.21.67.8.55 4.56-1.52 7.85-5.83 7.85-10.91C23.5 5.65 18.35.5 12 .5z"/>
+        </svg>
+        <span>github.com/DeepTempo/socbench</span>
+        <span class="cta-arrow" aria-hidden="true">&rarr;</span>
+      </a>
+    </div>
+    <div class="footer-origin">
+      <div class="footer-origin-label">Built with</div>
+      <div class="footer-origin-logos">
+        <a href="https://deeptempo.ai" target="_blank" rel="noopener" class="footer-origin-item" aria-label="DeepTempo">
+          <img src="img/deeptempo-logo.png" alt="DeepTempo" />
+          <span class="footer-origin-caption">deeptempo.ai <span aria-hidden="true">&#8599;</span></span>
+        </a>
+        <a href="https://github.com/Vigil-SOC/vigil" target="_blank" rel="noopener" class="footer-origin-item" aria-label="Vigil">
+          <img src="img/vigil-logo.png" alt="Vigil" />
+          <span class="footer-origin-caption">Vigil-SOC/vigil <span aria-hidden="true">&#8599;</span></span>
+        </a>
+      </div>
+    </div>
+  </div>
+  <div class="footer-bottom">
+    <span>SOCBench &middot; open benchmark for AI in cybersecurity operations</span>
+    <span>Apache 2.0</span>
+  </div>
 </footer>
 
 </body>

--- a/docs/website/index.html
+++ b/docs/website/index.html
@@ -61,7 +61,7 @@
         <svg viewBox="0 0 16 16" width="11" height="11" fill="currentColor" aria-hidden="true"><path d="M8 0l2 6h6l-5 3.5L13 16 8 12 3 16l2-6.5L0 6h6z"/></svg>
         NEW
       </span>
-      <span class="announcement-text">The vulnerability remediation harness (PatchLoop) is live. <a href="patchloop/">See it in action <span aria-hidden="true">→</span></a></span>
+      <span class="announcement-text">On PatchEval (ByteDance), PatchLoop clears OpenHands and SWE-agent by 20+ points. <a href="patchloop/">See how <span aria-hidden="true">→</span></a></span>
     </div>
   </div>
 </div>

--- a/docs/website/js/main.js
+++ b/docs/website/js/main.js
@@ -496,7 +496,7 @@
           ${data.perPersona.map(r => `
             <tr>
               <td class="provider-cell">${providerLabel(r.provider)}</td>
-              <td class="persona-cell">${r.persona || "—"}</td>
+              <td class="persona-cell">${r.persona || "-"}</td>
               <td class="num">${fmtPct(r.fpv)}</td>
               <td class="num">${fmtF1(r.verdictAcc)}</td>
               <td class="num">${fmtF1(r.verdictF1)}</td>

--- a/docs/website/js/patchloop.js
+++ b/docs/website/js/patchloop.js
@@ -1,0 +1,345 @@
+// SOCBench vuln-harness page interactive layer.
+// Tab switching + two step-through animations (harness verification loop, and a
+// side-by-side vs tool-calling agent). Extracted from the original patchloop
+// demo with two changes:
+//   1. `.tab` and `.tabs` renamed to `.harness-tab` and `.harness-tabs` so the
+//      controller cannot capture any landing-style segmented control dropped
+//      into a panel later.
+//   2. Em-dashes and en-dashes in string literals substituted with periods,
+//      colons, or hyphens (site-wide copy rule).
+// All original behavior preserved.
+
+(() => {
+  const $ = (id) => document.getElementById(id);
+
+  // ---- tabs ----
+  document.querySelectorAll(".harness-tab").forEach((tab) => {
+    tab.addEventListener("click", () => {
+      document.querySelectorAll(".harness-tab").forEach((t) => {
+        t.classList.toggle("active", t === tab);
+        t.setAttribute("aria-selected", t === tab ? "true" : "false");
+      });
+      document.querySelectorAll(".panel").forEach((p) => {
+        p.classList.toggle("active", p.id === "panel-" + tab.dataset.tab);
+      });
+    });
+  });
+
+  // ============================================================
+  // TAB 1. harness animation
+  // ============================================================
+  const nodes = ["n-finding", "n-router", "n-propose", "n-apply", "n-verify"].map($);
+  const verifiers = { rescan: $("v-rescan"), regress: $("v-regress"), repro: $("v-repro") };
+  const logEl = $("log");
+
+  function log(text, cls) {
+    const d = document.createElement("div");
+    d.textContent = text;
+    if (cls) d.className = cls;
+    logEl.appendChild(d);
+    logEl.scrollTop = logEl.scrollHeight;
+  }
+  function clearActive() {
+    nodes.forEach((n) => n.classList.remove("active", "failed", "passed"));
+  }
+  function focusNode(id) {
+    clearActive();
+    if (id) $(id).classList.add("active");
+  }
+  function setVerifier(name, state) {
+    const v = verifiers[name];
+    v.classList.remove("running", "pass", "fail", "skipped");
+    if (state) v.classList.add(state);
+  }
+  function resetVerifiers() {
+    for (const name of Object.keys(verifiers)) setVerifier(name, null);
+  }
+  function litRule(n, on) {
+    $("r" + n).classList.toggle("lit", on);
+  }
+
+  const timeline = [
+    { fn: () => { focusNode("n-finding"); log("finding CVE-2099-0001 decoded (Schema.Class). Untrusted JSON validated at the edge", "sys"); } },
+    { fn: () => { focusNode("n-router"); $("k-cve").classList.add("lit"); log('router: kind "cve" -> CVE patching harness'); } },
+
+    { fn: () => { $("attemptNum").textContent = "1"; focusNode("n-propose"); resetVerifiers(); log("attempt 1: propose. direct-edit request (feedback = null)"); } },
+    { fn: () => { focusNode("n-apply"); log("apply: 2 edits onto workspace ✓"); } },
+    { fn: () => { focusNode("n-verify"); setVerifier("rescan", "running"); log("verify: trivy rescan...", "wrn"); } },
+    { fn: () => { setVerifier("rescan", "fail"); setVerifier("regress", "skipped"); setVerifier("repro", "skipped");
+                  $("n-verify").classList.add("failed");
+                  log("rescan FAIL: CVE-2099-0001 still reported", "err");
+                  log("fail-fast: never paid for tests or PoC", "sys"); } },
+    { fn: () => { $("feedback").classList.add("active"); litRule(2, true);
+                  log("feedback <- verbatim scanner output + cumulative diff", "wrn");
+                  log("rule 2: repair ON TOP of patched state (no reset)", "sys"); } },
+
+    { fn: () => { $("feedback").classList.remove("active"); $("attemptNum").textContent = "2";
+                  focusNode("n-propose"); resetVerifiers(); litRule(2, false);
+                  log("attempt 2: propose. repair prompt carries current (patched) files"); } },
+    { fn: () => { focusNode("n-apply"); log("apply: 1 edit onto patched state ✓"); } },
+    { fn: () => { focusNode("n-verify"); setVerifier("rescan", "running"); log("verify: trivy rescan...", "wrn"); } },
+    { fn: () => { setVerifier("rescan", "pass"); setVerifier("regress", "running"); log("rescan PASS. finding gone", "ok"); log("verify: make test...", "wrn"); } },
+    { fn: () => { setVerifier("regress", "fail"); setVerifier("repro", "skipped"); $("n-verify").classList.add("failed");
+                  log("regression FAIL: 2 tests broken. patch deleted the feature", "err");
+                  log("a rescan-passing patch is not a done patch", "sys"); } },
+    { fn: () => { $("feedback").classList.add("active"); litRule(4, true);
+                  log("feedback <- verbatim test output + cumulative diff", "wrn"); } },
+
+    { fn: () => { $("feedback").classList.remove("active"); $("attemptNum").textContent = "3";
+                  focusNode("n-propose"); resetVerifiers(); litRule(4, false);
+                  log("attempt 3: propose. restore behavior, keep the sanitization"); } },
+    { fn: () => { focusNode("n-apply"); log("apply: 1 edit ✓"); } },
+    { fn: () => { focusNode("n-verify"); setVerifier("rescan", "running"); log("verify: trivy rescan...", "wrn"); } },
+    { fn: () => { setVerifier("rescan", "pass"); setVerifier("regress", "running"); log("rescan PASS", "ok"); log("verify: make test...", "wrn"); } },
+    { fn: () => { setVerifier("regress", "pass"); setVerifier("repro", "running"); log("regression PASS. 214/214 tests", "ok"); log("verify: run exploit PoC...", "wrn"); } },
+    { fn: () => { setVerifier("repro", "pass"); $("n-verify").classList.add("passed"); litRule(5, true);
+                  log("reproduction PASS. exploit no longer works", "ok"); } },
+    { fn: () => { clearActive();
+                  const o = $("outcome");
+                  o.classList.add("success");
+                  o.textContent = "✓ verified diff -> open pull request (your side of the fence)";
+                  log("result: success=true, attempts=3, finalDiff -> PR", "ok"); } },
+  ];
+
+  let i = 0, timer = null, playing = false;
+  const playBtn = $("playBtn");
+
+  function step() {
+    if (i >= timeline.length) { stop(); return; }
+    timeline[i++].fn();
+    if (playing && i < timeline.length) {
+      timer = setTimeout(step, parseInt($("speedSel").value, 10));
+    } else if (i >= timeline.length) {
+      stop();
+    }
+  }
+  function stop() {
+    playing = false;
+    clearTimeout(timer);
+    playBtn.innerHTML = "&#9654; Play";
+  }
+  function reset() {
+    stop();
+    i = 0;
+    clearActive();
+    resetVerifiers();
+    [1, 2, 3, 4, 5].forEach((n) => litRule(n, false));
+    $("k-cve").classList.remove("lit");
+    $("feedback").classList.remove("active");
+    $("attemptNum").textContent = "-";
+    const o = $("outcome");
+    o.classList.remove("success");
+    o.textContent = "awaiting verified diff...";
+    logEl.innerHTML = '<div class="sys">// press Play to run a remediation</div>';
+  }
+  playBtn.addEventListener("click", () => {
+    if (playing) { stop(); return; }
+    if (i >= timeline.length) reset();
+    playing = true;
+    playBtn.innerHTML = "&#10074;&#10074; Pause";
+    step();
+  });
+  $("stepBtn").addEventListener("click", () => { stop(); if (i >= timeline.length) reset(); else step(); });
+  $("resetBtn").addEventListener("click", reset);
+
+  // ============================================================
+  // TAB 2. vs tool-calling agent
+  // ============================================================
+  const SYS = 20000;
+  const AGENT_STEPS = [
+    { tool: "Think", add: 1200 },
+    { tool: "Glob",  add: 400 },
+    { tool: "Think", add: 900 },
+    { tool: "Read",  add: 2100 },
+    { tool: "Think", add: 1400 },
+    { tool: "Grep",  add: 600 },
+    { tool: "Think", add: 1100 },
+    { tool: "Edit",  add: 800 },
+    { tool: "Think", add: 1000 },
+    { tool: "Bash",  add: 1500 },
+    { tool: "Think", add: 1300 },
+    { tool: "Edit",  add: 700 },
+    { tool: "text",  add: 400 },
+  ];
+  const PATCH_STEPS = [
+    { add: 3000 },
+    { add: 0 },
+    { add: 0 },
+    { add: 3500 },
+    { add: 0 },
+  ];
+  const USD_PER_TOK = 5 / 1_000_000;
+  const MAX_TOK = 48000;
+
+  let vsTimer = null;
+  let vsPlaying = false;
+
+  function fmtTok(n) {
+    if (n >= 1000) return (n / 1000).toFixed(n >= 10000 ? 0 : 1) + "k";
+    return String(n);
+  }
+  function fmtUsd(n) {
+    return "$" + n.toFixed(2);
+  }
+  function setMeter(tokId, barId, costId, n) {
+    $(tokId).textContent = fmtTok(n);
+    $(barId).style.width = Math.min(100, (n / MAX_TOK) * 100) + "%";
+    $(costId).textContent = fmtUsd(n * USD_PER_TOK);
+  }
+
+  function vsReset() {
+    vsPlaying = false;
+    clearTimeout(vsTimer);
+    $("vsPlay").innerHTML = "&#9654; Run both on the same CVE";
+    document.querySelectorAll("#agentTurns .turn, #patchTurns .turn").forEach((t) => {
+      t.classList.remove("active", "done", "final");
+      t.classList.add("ghost");
+    });
+    document.querySelectorAll("#agentTools .tool-chip").forEach((c) => c.classList.remove("lit"));
+    setMeter("agentTok", "agentBar", "agentCost", 0);
+    setMeter("patchTok", "patchBar", "patchCost", 0);
+    $("punchAgent").textContent = "~45k tok";
+    $("punchPatch").textContent = "~7k tok";
+    $("punchRatio").textContent = "~10x";
+  }
+
+  function litTool(name) {
+    document.querySelectorAll("#agentTools .tool-chip").forEach((c) => {
+      c.classList.toggle("lit", c.dataset.t === name || (name === "text" && false));
+    });
+  }
+
+  function vsRun() {
+    if (vsPlaying) {
+      vsPlaying = false;
+      clearTimeout(vsTimer);
+      $("vsPlay").innerHTML = "&#9654; Run both on the same CVE";
+      return;
+    }
+    vsReset();
+    vsPlaying = true;
+    $("vsPlay").innerHTML = "&#10074;&#10074; Pause";
+
+    let agentTok = 0;
+    let patchTok = 0;
+    let a = 0;
+    let p = 0;
+    agentTok = SYS;
+    setMeter("agentTok", "agentBar", "agentCost", agentTok);
+
+    const agentTurns = [...document.querySelectorAll("#agentTurns .turn")];
+    const patchTurns = [...document.querySelectorAll("#patchTurns .turn")];
+
+    function tickAgent() {
+      if (!vsPlaying) return;
+      if (a >= AGENT_STEPS.length) {
+        maybeDone();
+        return;
+      }
+      const stp = AGENT_STEPS[a];
+      const sysTax = a === 0 ? 0 : Math.round(SYS * 0.15);
+      agentTok += sysTax + stp.add;
+      agentTurns.forEach((t, idx) => {
+        t.classList.remove("active", "ghost");
+        if (idx < a) t.classList.add("done");
+        else if (idx === a) t.classList.add("active");
+        else t.classList.add("ghost");
+      });
+      litTool(stp.tool);
+      setMeter("agentTok", "agentBar", "agentCost", agentTok);
+      a++;
+      if (a >= AGENT_STEPS.length) {
+        agentTurns.forEach((t) => { t.classList.remove("active"); t.classList.add("done"); });
+        agentTurns[agentTurns.length - 1].classList.add("final");
+        litTool("");
+        $("punchAgent").textContent = "~" + fmtTok(agentTok) + " tok";
+      }
+      vsTimer = setTimeout(tickAgent, 420);
+      maybeStartPatch();
+    }
+
+    let patchStarted = false;
+    function maybeStartPatch() {
+      if (patchStarted || a < 2) return;
+      patchStarted = true;
+      tickPatch();
+    }
+
+    function tickPatch() {
+      if (!vsPlaying) return;
+      if (p >= PATCH_STEPS.length) {
+        maybeDone();
+        return;
+      }
+      const stp = PATCH_STEPS[p];
+      patchTok += stp.add;
+      patchTurns.forEach((t, idx) => {
+        t.classList.remove("active", "ghost");
+        if (idx < p) t.classList.add("done");
+        else if (idx === p) t.classList.add("active");
+        else t.classList.add("ghost");
+      });
+      setMeter("patchTok", "patchBar", "patchCost", patchTok);
+      p++;
+      if (p >= PATCH_STEPS.length) {
+        patchTurns.forEach((t) => { t.classList.remove("active"); t.classList.add("done"); });
+        patchTurns[patchTurns.length - 1].classList.add("final");
+        $("punchPatch").textContent = "~" + fmtTok(patchTok) + " tok";
+        const ratio = Math.round(agentTok / Math.max(patchTok, 1));
+        $("punchRatio").textContent = "~" + ratio + "x";
+      }
+      vsTimer = setTimeout(tickPatch, 700);
+    }
+
+    function maybeDone() {
+      if (a >= AGENT_STEPS.length && p >= PATCH_STEPS.length) {
+        vsPlaying = false;
+        $("vsPlay").innerHTML = "&#9654; Run both on the same CVE";
+        const ratio = Math.round(agentTok / Math.max(patchTok, 1));
+        $("punchAgent").textContent = "~" + fmtTok(agentTok) + " tok";
+        $("punchPatch").textContent = "~" + fmtTok(patchTok) + " tok";
+        $("punchRatio").textContent = "~" + ratio + "x";
+      }
+    }
+
+    tickAgent();
+  }
+
+  $("vsPlay").addEventListener("click", vsRun);
+  $("vsReset").addEventListener("click", vsReset);
+
+  // ============================================================
+  // GitHub star count for the nav pill (shared with landing).
+  // Public REST API, 5-minute localStorage cache to avoid re-hitting.
+  // ============================================================
+  (function loadStarCount() {
+    const el = document.getElementById("repo-star-count");
+    if (!el) return;
+    const REPO = "DeepTempo/socbench";
+    const CACHE_KEY = `gh-stars-${REPO}`;
+    const TTL_MS = 5 * 60 * 1000;
+    function fmt(n) {
+      if (n == null) return "";
+      if (n >= 1000) return (n / 1000).toFixed(1).replace(/\.0$/, "") + "k";
+      return String(n);
+    }
+    try {
+      const raw = localStorage.getItem(CACHE_KEY);
+      if (raw) {
+        const { count, at } = JSON.parse(raw);
+        if (Date.now() - at <= TTL_MS) {
+          el.textContent = fmt(count);
+          return;
+        }
+      }
+    } catch {}
+    fetch(`https://api.github.com/repos/${REPO}`)
+      .then(r => r.ok ? r.json() : Promise.reject(r.status))
+      .then(d => {
+        const c = d.stargazers_count;
+        el.textContent = fmt(c);
+        try { localStorage.setItem(CACHE_KEY, JSON.stringify({ count: c, at: Date.now() })); } catch {}
+      })
+      .catch(() => {});
+  })();
+})();

--- a/docs/website/patchloop/index.html
+++ b/docs/website/patchloop/index.html
@@ -80,8 +80,12 @@
        TAB 1. VERIFICATION LOOP
        ============================================================ -->
   <div class="panel active" id="panel-harness">
+    <div class="patcheval-disclaimer" role="note" style="margin:0 0 1.25rem;padding:0.85rem 1rem;border-left:3px solid var(--warn,#e0a458);background:rgba(224,164,88,0.08);border-radius:6px;font-size:0.92rem;line-height:1.5">
+      <strong>Disclaimer.</strong> These results are from the original <a href="https://github.com/bytedance/PatchEval" target="_blank" rel="noopener">PatchEval</a> benchmark. On July 24, 2026 &mdash; after these runs &mdash; ByteDance released <strong>PatchEval-Verified</strong>, with revised Docker environments and a new leaderboard. The numbers on this page predate that release and are <strong>not comparable</strong> to PatchEval-Verified. We plan to re-run against the updated version and will follow up.
+    </div>
+
     <div class="patcheval-block patcheval-block--master">
-      <div class="patcheval-block-label">PatchLoop on PatchEval</div>
+      <div class="patcheval-block-label">PatchLoop on PatchEval (original)</div>
       <div class="patcheval-hero-inline">
         <span class="patcheval-hero-num">+25.2pp</span>
         <span class="patcheval-hero-lbl">from PatchLoop with feedback loop</span>
@@ -93,13 +97,13 @@
         <div class="stat"><div class="val">&le;3</div><div class="lbl">bounded attempts</div></div>
       </div>
       <p class="patcheval-note">
-        <a href="https://github.com/bytedance/PatchEval" target="_blank" rel="noopener"><strong>PatchEval-Verified</strong></a> (ByteDance) is a benchmark of 230 real-world CVEs from 2015 to 2025, across Go, JavaScript, and Python. Each case ships as a Docker image containing the vulnerable repo and a validation entrypoint that checks whether the vulnerability is still exploitable after a patch.
+        <a href="https://github.com/bytedance/PatchEval" target="_blank" rel="noopener"><strong>PatchEval</strong></a> (ByteDance) is a benchmark of 230 real-world CVEs from 2015 to 2025, across Go, JavaScript, and Python. Each case ships as a Docker image containing the vulnerable repo and a validation entrypoint that checks whether the vulnerability is still exploitable after a patch.
       </p>
     </div>
 
-    <!-- Leaderboard comparison: PatchLoop vs the current best agent frameworks on PatchEval-Verified -->
+    <!-- Leaderboard comparison: PatchLoop vs the agent frameworks on the original PatchEval board -->
     <div class="pev-leaderboard">
-      <div class="pev-leaderboard-label">vs. PatchEval-Verified leaderboard</div>
+      <div class="pev-leaderboard-label">vs. original PatchEval leaderboard</div>
       <div class="table-wrap">
         <table class="pev-table">
           <thead>
@@ -163,7 +167,7 @@
         </table>
       </div>
       <p class="pev-leaderboard-footnote">
-        The verify-feedback loop clears the entire agent leaderboard by ~21pp. Values as of 2026-07-27. Source: <a href="https://github.com/bytedance/PatchEval" target="_blank" rel="noopener">bytedance/PatchEval</a>.
+        Board rows are from the original PatchEval leaderboard (values as of 2026-07-27). PatchLoop's verify-feedback row uses validation output, so it was not eligible for that leaderboard and is shown for context only. See the disclaimer above regarding <a href="https://github.com/bytedance/PatchEval" target="_blank" rel="noopener">PatchEval-Verified</a>.
       </p>
     </div>
 

--- a/docs/website/patchloop/index.html
+++ b/docs/website/patchloop/index.html
@@ -1,0 +1,436 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>PatchLoop: Vulnerability Detection and Patching Harness · SOCBench</title>
+  <meta name="description" content="PatchLoop is SOCBench's vulnerability detection and patching harness. Propose a patch, apply it, verify it with your own detectors, repair on top of the patched state. Bounded attempts, typed errors, fail-fast verification." />
+  <link rel="stylesheet" href="../css/style.css" />
+  <link rel="stylesheet" href="../css/harness.css" />
+  <script src="../js/patchloop.js" defer></script>
+</head>
+<body class="harness-page harness-patchloop">
+
+<!-- ============================================================ -->
+<!-- sticky nav (shared shell, copied from landing with 4 edits)  -->
+<!-- ============================================================ -->
+<nav class="nav">
+  <div class="nav-inner">
+    <a class="nav-brand" href="../#overview"><span class="dot"></span>SOCBench</a>
+    <div class="nav-links">
+      <a href="../#overview">Overview</a>
+      <a href="../detection/">Detection</a>
+      <a href="../patchloop/">PatchLoop</a>
+    </div>
+    <span class="nav-current" aria-current="page">PatchLoop</span>
+    <div class="repo-pill" role="group" aria-label="GitHub repository">
+      <a class="repo-pill-half repo-pill-left" href="https://github.com/DeepTempo/socbench" target="_blank" rel="noopener" aria-label="View on GitHub">
+        <svg viewBox="0 0 24 24" width="18" height="18" fill="currentColor" aria-hidden="true">
+          <path d="M12 .5C5.65.5.5 5.65.5 12c0 5.08 3.29 9.39 7.86 10.91.58.11.79-.25.79-.55v-2.17c-3.2.7-3.88-1.37-3.88-1.37-.53-1.34-1.3-1.7-1.3-1.7-1.06-.72.08-.71.08-.71 1.17.08 1.79 1.2 1.79 1.2 1.04 1.78 2.73 1.27 3.4.97.1-.75.41-1.27.74-1.56-2.55-.29-5.24-1.28-5.24-5.7 0-1.26.45-2.29 1.19-3.1-.12-.29-.52-1.46.11-3.05 0 0 .97-.31 3.18 1.18a11 11 0 0 1 5.8 0c2.21-1.49 3.18-1.18 3.18-1.18.63 1.59.23 2.76.11 3.05.74.81 1.19 1.84 1.19 3.1 0 4.43-2.69 5.41-5.25 5.69.42.36.79 1.07.79 2.16v3.2c0 .31.21.67.8.55 4.56-1.52 7.85-5.83 7.85-10.91C23.5 5.65 18.35.5 12 .5z"/>
+        </svg>
+        <span>GitHub</span>
+      </a>
+      <span class="repo-pill-divider" aria-hidden="true"></span>
+      <a class="repo-pill-half" href="https://github.com/DeepTempo/socbench" target="_blank" rel="noopener" aria-label="Star DeepTempo/socbench on GitHub">
+        <svg viewBox="0 0 16 16" width="16" height="16" fill="currentColor" aria-hidden="true">
+          <path d="M8 .25a.75.75 0 0 1 .673.418l1.882 3.815 4.21.612a.75.75 0 0 1 .416 1.279l-3.046 2.97.719 4.192a.75.75 0 0 1-1.088.791L8 12.347l-3.766 1.98a.75.75 0 0 1-1.088-.79l.72-4.194L.818 6.374a.75.75 0 0 1 .416-1.28l4.21-.611L7.327.668A.75.75 0 0 1 8 .25z"/>
+        </svg>
+        <span>Star</span>
+        <span class="repo-pill-count" id="repo-star-count" aria-label="star count"></span>
+      </a>
+    </div>
+  </div>
+</nav>
+
+<!-- ============================================================ -->
+<!-- harness-context strip (replaces the landing announcement)    -->
+<!-- ============================================================ -->
+<div class="page-context">
+  <div class="page-context-inner">
+    <a class="page-context-back" href="../#capabilities">&larr; Back to capabilities</a>
+    <span class="page-context-crumb">
+      Capability: <strong>Vulnerability detection and patching</strong>. Implementation: <strong>PatchLoop</strong>. Status: Live.
+    </span>
+  </div>
+</div>
+
+<!-- ============================================================ -->
+<!-- page body: original patchloop content, verbatim (em/en dash swept only) -->
+<!-- ============================================================ -->
+<div class="page">
+  <header>
+    <h1><span class="mono">PatchLoop</span>: Vulnerability Detection and Patching Harness</h1>
+    <div class="sub">
+      <b>Verify with the machinery that raised the alert.</b> Propose a patch, apply it, verify it with your own detectors, feed the verbatim failure back to the model, and repair on top of the patched state. Bounded attempts, typed errors, fail-fast verification.
+    </div>
+  </header>
+
+  <div class="harness-tabs" role="tablist">
+    <button class="harness-tab active" data-tab="harness" role="tab" aria-selected="true">
+      Verification Loop
+      <span class="hint">propose &rarr; apply &rarr; verify &rarr; repair</span>
+    </button>
+    <button class="harness-tab" data-tab="contrast" role="tab" aria-selected="false">
+      vs Claude Code like agents
+      <span class="hint">why PatchLoop is ~10x cheaper</span>
+    </button>
+  </div>
+
+  <!-- ============================================================
+       TAB 1. VERIFICATION LOOP
+       ============================================================ -->
+  <div class="panel active" id="panel-harness">
+    <div class="patcheval-block patcheval-block--master">
+      <div class="patcheval-block-label">PatchLoop on PatchEval</div>
+      <div class="patcheval-hero-inline">
+        <span class="patcheval-hero-num">+25.2pp</span>
+        <span class="patcheval-hero-lbl">from PatchLoop with feedback loop</span>
+      </div>
+      <div class="patcheval-supports">
+        <div class="stat"><div class="val accent">57.4%</div><div class="lbl">one verify-feedback round (132/230)</div></div>
+        <div class="stat"><div class="val">33.5%</div><div class="lbl">PatchEval strict, no feedback (77/230)</div></div>
+        <div class="stat"><div class="val warn">~$0.17</div><div class="lbl">per CVE</div></div>
+        <div class="stat"><div class="val">&le;3</div><div class="lbl">bounded attempts</div></div>
+      </div>
+      <p class="patcheval-note">
+        <a href="https://github.com/bytedance/PatchEval" target="_blank" rel="noopener"><strong>PatchEval-Verified</strong></a> (ByteDance) is a benchmark of 230 real-world CVEs from 2015 to 2025, across Go, JavaScript, and Python. Each case ships as a Docker image containing the vulnerable repo and a validation entrypoint that checks whether the vulnerability is still exploitable after a patch.
+      </p>
+    </div>
+
+    <!-- Leaderboard comparison: PatchLoop vs the current best agent frameworks on PatchEval-Verified -->
+    <div class="pev-leaderboard">
+      <div class="pev-leaderboard-label">vs. PatchEval-Verified leaderboard</div>
+      <div class="table-wrap">
+        <table class="pev-table">
+          <thead>
+            <tr>
+              <th>System</th>
+              <th>Model</th>
+              <th>Type</th>
+              <th class="num">Overall</th>
+              <th class="num">Go</th>
+              <th class="num">Python</th>
+              <th class="num">Node.js</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr class="pev-row-patchloop">
+              <td class="provider-cell">PatchLoop</td>
+              <td class="provider-cell">gpt-5-codex</td>
+              <td>verify-feedback loop</td>
+              <td class="num"><strong>57.4%</strong></td>
+              <td class="num">50.6%</td>
+              <td class="num">61.4%</td>
+              <td class="num">61.0%</td>
+            </tr>
+            <tr>
+              <td class="provider-cell"><a href="https://github.com/All-Hands-AI/OpenHands" target="_blank" rel="noopener">OpenHands <span aria-hidden="true">&#8599;</span></a></td>
+              <td class="provider-cell">GPT-5</td>
+              <td>agent</td>
+              <td class="num">36.1%</td>
+              <td class="num">36.1%</td>
+              <td class="num">26.8%</td>
+              <td class="num">44.7%</td>
+            </tr>
+            <tr>
+              <td class="provider-cell"><a href="https://github.com/anthropics/claude-code" target="_blank" rel="noopener">ClaudeCode <span aria-hidden="true">&#8599;</span></a></td>
+              <td class="provider-cell">GPT-5</td>
+              <td>agent</td>
+              <td class="num">34.4%</td>
+              <td class="num">38.5%</td>
+              <td class="num">22.5%</td>
+              <td class="num">40.8%</td>
+            </tr>
+            <tr class="pev-row-patchloop-base">
+              <td class="provider-cell">PatchLoop</td>
+              <td class="provider-cell">gpt-5-codex</td>
+              <td>base LLM, no loop</td>
+              <td class="num">33.5%</td>
+              <td class="num">-</td>
+              <td class="num">-</td>
+              <td class="num">-</td>
+            </tr>
+            <tr>
+              <td class="provider-cell"><a href="https://github.com/SWE-agent/SWE-agent" target="_blank" rel="noopener">SWE-agent <span aria-hidden="true">&#8599;</span></a></td>
+              <td class="provider-cell">GPT-5</td>
+              <td>agent</td>
+              <td class="num">33.0%</td>
+              <td class="num">32.5%</td>
+              <td class="num">22.5%</td>
+              <td class="num">43.4%</td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+      <p class="pev-leaderboard-footnote">
+        The verify-feedback loop clears the entire agent leaderboard by ~21pp. Values as of 2026-07-27. Source: <a href="https://github.com/bytedance/PatchEval" target="_blank" rel="noopener">bytedance/PatchEval</a>.
+      </p>
+    </div>
+
+    <div class="controls">
+      <button class="primary" id="playBtn">&#9654; Play</button>
+      <button id="stepBtn">Step</button>
+      <button id="resetBtn">Restart</button>
+      <select id="speedSel">
+        <option value="1600">Slow</option>
+        <option value="1000" selected>Normal</option>
+        <option value="550">Fast</option>
+      </select>
+      <div class="attempt-pill">attempt <b id="attemptNum">-</b> / 3</div>
+    </div>
+
+    <div class="stage-wrap">
+      <div class="stage">
+        <div class="flow">
+          <div class="node" id="n-finding">
+            <h3>Finding</h3>
+            <p>Normalized, schema-validated at the edge (<span style="font-family:var(--mono)">decodeFinding</span>).</p>
+            <span class="tag">CVE-2099-0001</span>
+            <span class="tag">path traversal</span>
+          </div>
+          <div class="arrow-col">
+            <div class="node" id="n-router" style="width:100%">
+              <h3>Router</h3>
+              <p>kind &rarr; harness</p>
+            </div>
+            <div class="kinds" style="margin-top:0.5rem">
+              <span class="kind" id="k-cve">cve &rarr; CVE harness</span>
+              <span class="kind">pentest &rarr; PoC harness</span>
+              <span class="kind">... &rarr; yours</span>
+            </div>
+          </div>
+
+          <div class="loop-box">
+            <div class="loop-title">RemediationHarness. the loop</div>
+            <div class="loop-row">
+              <div class="node" id="n-propose">
+                <h3>Propose</h3>
+                <p>One structured direct-edit request. No agent round-trips.</p>
+                <span class="tag">DirectEditPatcher</span>
+              </div>
+              <div class="node" id="n-apply">
+                <h3>Apply</h3>
+                <p>Exact search/replace onto the git workspace.</p>
+                <span class="tag">GitWorkspace</span>
+              </div>
+              <div class="node" id="n-verify">
+                <h3>Verify: cheapest first, fail fast</h3>
+                <div class="verifiers">
+                  <div class="verifier" id="v-rescan"><span class="dot"></span> Rescan: finding id gone? <span class="cost">cheap</span></div>
+                  <div class="verifier" id="v-regress"><span class="dot"></span> Regression: tests still pass? <span class="cost">moderate</span></div>
+                  <div class="verifier" id="v-repro"><span class="dot"></span> Reproduction: PoC dead? <span class="cost">expensive</span></div>
+                </div>
+              </div>
+            </div>
+            <div class="feedback-arc" id="feedback">
+              <span class="arrow">&#8617;</span>
+              <span id="feedbackText">Feedback path: verbatim failure output + cumulative diff &rarr; repair ON TOP of patched state</span>
+            </div>
+            <div class="outcome" id="outcome">awaiting verified diff...</div>
+          </div>
+        </div>
+      </div>
+
+      <div class="log-panel">
+        <h3>Harness log</h3>
+        <div class="log" id="log"><div class="sys">// press Play to run a remediation</div></div>
+      </div>
+    </div>
+
+    <div class="rules">
+      <div class="rule" id="r1"><b><span class="n">1</span>Empty patch &ne; success</b>The largest silent-failure bucket in early runs. Counted as a failed attempt with explicit feedback.</div>
+      <div class="rule" id="r2"><b><span class="n">2</span>Repair on patched state</b>No reset between attempts. Prompt carries current files, cumulative diff, verbatim failure.</div>
+      <div class="rule" id="r3"><b><span class="n">3</span>Reset only on bad apply</b>Workspace no longer matches what the model believes. Start clean and say so.</div>
+      <div class="rule" id="r4"><b><span class="n">4</span>Crashing verifier = failure</b><span style="font-family:var(--mono)">catchAllCause</span>: any defect becomes a failed verdict. Enforced by types, not a remembered try/catch.</div>
+      <div class="rule" id="r5"><b><span class="n">5</span>Bounded attempts</b>The first feedback round buys the most; returns fall off fast after 2 to 3.</div>
+    </div>
+  </div>
+
+  <!-- ============================================================
+       TAB 2. VS TOOL-CALLING AGENT
+       ============================================================ -->
+  <div class="panel" id="panel-contrast">
+    <div class="contrast-lede">
+      A general coding agent (Claude Code style) is built for <b>open-ended</b> work: a ~20k-token system prompt,
+      a catalog of built-in tools + MCPs, and a forced <span style="font-family:var(--mono)">&lt;think&gt; &rarr; tool &rarr; &lt;think&gt;</span>
+      loop until it finally emits text. For a scoped job (patch this CVE), we already know the shape of the answer.
+      So we skip all of that overhead and spend the intelligence budget on the verification loop instead.
+    </div>
+
+    <div class="controls">
+      <button class="primary ctl" id="vsPlay">&#9654; Run both on the same CVE</button>
+      <button class="ctl" id="vsReset">Restart</button>
+      <div class="attempt-pill">same finding · <b>CVE-2099-0001</b></div>
+    </div>
+
+    <div class="vs-grid">
+      <!-- LEFT: general agent -->
+      <div class="vs-col agent">
+        <div class="vs-head">
+          <h3>General tool-calling agent</h3>
+          <span class="badge">Claude Code style</span>
+        </div>
+
+        <div class="payload">
+          <div class="plabel">Context every turn</div>
+          <div class="tokens fat">system prompt &asymp; <b id="agentSysTok">~20,000</b> tokens · re-sent every round</div>
+          <div class="sys-prompt" id="agentSys">
+You are Claude Code, Anthropic's official CLI for Claude.
+You are an interactive CLI tool that helps users with software engineering tasks.
+Use the instructions below and the tools available to you to assist the user.
+
+IMPORTANT: Assist with defensive security tasks only...
+Always follow these principles when writing code...
+Do what has been asked; nothing more, nothing less...
+NEVER create files unless they're absolutely necessary...
+Prefer editing existing files...
+When writing commit messages or PR descriptions...
+Be careful not to introduce security vulnerabilities...
+[...continues for ~20k tokens of tool schemas, MCP wiring, style rules, examples...]
+          </div>
+          <div class="plabel" style="margin-top:0.65rem">Tool catalog (schemas + descriptions, every turn)</div>
+          <div class="tool-catalog" id="agentTools">
+            <span class="tool-chip" data-t="Think">Think</span>
+            <span class="tool-chip" data-t="Read">Read</span>
+            <span class="tool-chip" data-t="Glob">Glob</span>
+            <span class="tool-chip" data-t="Grep">Grep</span>
+            <span class="tool-chip" data-t="Edit">Edit</span>
+            <span class="tool-chip" data-t="Write">Write</span>
+            <span class="tool-chip" data-t="Bash">Bash</span>
+            <span class="tool-chip" data-t="MCP">MCPxN</span>
+          </div>
+        </div>
+
+        <div class="loop-title" style="margin-bottom:0.45rem">Forced turn loop</div>
+        <div class="turn-rail" id="agentTurns">
+          <div class="turn ghost" data-i="0"><span class="tag">&lt;think&gt;</span><span class="body">plan approach...</span><span class="tok">+1.2k</span></div>
+          <div class="turn ghost" data-i="1"><span class="tag">Glob</span><span class="body">**/*download*</span><span class="tok">+0.4k</span></div>
+          <div class="turn ghost" data-i="2"><span class="tag">&lt;think&gt;</span><span class="body">narrow candidates...</span><span class="tok">+0.9k</span></div>
+          <div class="turn ghost" data-i="3"><span class="tag">Read</span><span class="body">src/api/download.ts</span><span class="tok">+2.1k</span></div>
+          <div class="turn ghost" data-i="4"><span class="tag">&lt;think&gt;</span><span class="body">locate traversal...</span><span class="tok">+1.4k</span></div>
+          <div class="turn ghost" data-i="5"><span class="tag">Grep</span><span class="body">path.join|../</span><span class="tok">+0.6k</span></div>
+          <div class="turn ghost" data-i="6"><span class="tag">&lt;think&gt;</span><span class="body">draft fix...</span><span class="tok">+1.1k</span></div>
+          <div class="turn ghost" data-i="7"><span class="tag">Edit</span><span class="body">sanitize path</span><span class="tok">+0.8k</span></div>
+          <div class="turn ghost" data-i="8"><span class="tag">&lt;think&gt;</span><span class="body">re-check neighbors...</span><span class="tok">+1.0k</span></div>
+          <div class="turn ghost" data-i="9"><span class="tag">Bash</span><span class="body">npm test</span><span class="tok">+1.5k</span></div>
+          <div class="turn ghost" data-i="10"><span class="tag">&lt;think&gt;</span><span class="body">fix one test...</span><span class="tok">+1.3k</span></div>
+          <div class="turn ghost" data-i="11"><span class="tag">Edit</span><span class="body">restore behavior</span><span class="tok">+0.7k</span></div>
+          <div class="turn ghost" data-i="12"><span class="tag">text</span><span class="body">"patched the CVE..."</span><span class="tok">+0.4k</span></div>
+        </div>
+
+        <div class="meter">
+          <div class="meter-row">
+            <span>cumulative tokens this CVE</span>
+            <span class="n" id="agentTok">0</span>
+          </div>
+          <div class="bar"><span id="agentBar"></span></div>
+          <div class="meter-row" style="margin-top:0.45rem">
+            <span>est. cost</span>
+            <span class="n" id="agentCost">$0.00</span>
+          </div>
+        </div>
+      </div>
+
+      <!-- RIGHT: patchloop -->
+      <div class="vs-col patch">
+        <div class="vs-head">
+          <h3>PatchLoop DirectEdit</h3>
+          <span class="badge">specialized harness</span>
+        </div>
+
+        <div class="payload">
+          <div class="plabel">Context: once per attempt</div>
+          <div class="tokens thin">finding + file contents &asymp; <b>~2 to 4k</b> tokens · no agent persona</div>
+          <div class="sys-prompt collapsed" style="mask-image:none; max-height:none; color:#8b95a5">
+Patch this finding with exact search/replace edits.
+Return only the structured EditPatch JSON.
+          </div>
+          <div class="plabel" style="margin-top:0.65rem">What we skip</div>
+          <div class="skip-list">
+            <div class="skip-item"><span class="x">x</span> 20k-token "you are a coding assistant..." system prompt</div>
+            <div class="skip-item"><span class="x">x</span> tool schemas, descriptions, MCP catalogs</div>
+            <div class="skip-item"><span class="x">x</span> forced &lt;think&gt; / Read / Glob / Bash round-trips</div>
+            <div class="skip-item"><span class="x">x</span> the model deciding <i>how</i> to explore. We already know the job.</div>
+          </div>
+        </div>
+
+        <div class="loop-title" style="margin-bottom:0.45rem">One structured request per attempt</div>
+        <div class="turn-rail" id="patchTurns">
+          <div class="turn ghost" data-i="0"><span class="tag">propose</span><span class="body">EditPatch JSON (attempt 1)</span><span class="tok">~3k</span></div>
+          <div class="turn ghost" data-i="1"><span class="tag">apply</span><span class="body">workspace.apply (free)</span><span class="tok">0</span></div>
+          <div class="turn ghost" data-i="2"><span class="tag">verify</span><span class="body">rescan / tests / PoC (your detectors)</span><span class="tok">0</span></div>
+          <div class="turn ghost" data-i="3"><span class="tag">propose</span><span class="body">repair on patched state (attempt 2)</span><span class="tok">~3.5k</span></div>
+          <div class="turn ghost" data-i="4"><span class="tag">verify</span><span class="body">passed &rarr; verified diff</span><span class="tok">0</span></div>
+        </div>
+
+        <div class="meter">
+          <div class="meter-row">
+            <span>cumulative tokens this CVE</span>
+            <span class="n" id="patchTok">0</span>
+          </div>
+          <div class="bar"><span id="patchBar"></span></div>
+          <div class="meter-row" style="margin-top:0.45rem">
+            <span>est. cost</span>
+            <span class="n" id="patchCost">$0.00</span>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <div class="punchline">
+      <div class="punch">
+        <div class="big danger" id="punchAgent">~45k tok</div>
+        <p>General agent: system prompt + tool schemas re-paid on every turn, then ~12 tool/think cycles before a text answer.</p>
+      </div>
+      <div class="punch">
+        <div class="big" id="punchPatch">~7k tok</div>
+        <p>PatchLoop: one structured propose per attempt. Verification is your scanners, not another model round-trip.</p>
+      </div>
+      <div class="punch">
+        <div class="big warn" id="punchRatio">~10x</div>
+        <p>cheaper for the same scoped job. Intelligence budget spent on the verify-feedback loop, the part that actually moved PatchEval +25pp.</p>
+      </div>
+    </div>
+  </div>
+
+</div>
+
+<!-- ============================================================ -->
+<!-- shared footer (landing style)                                -->
+<!-- ============================================================ -->
+<footer class="footer">
+  <div class="footer-inner">
+    <div class="footer-copy">
+      <div class="eyebrow">Run it yourself</div>
+      <h2>Reproduce</h2>
+      <p>SOCBench is open. Clone, set provider keys, run the launch entry point. Or skip the run and re-score the published artifacts directly. Everything lives in the repo.</p>
+      <a class="cta-button" href="https://github.com/DeepTempo/socbench" target="_blank" rel="noopener">
+        <svg viewBox="0 0 24 24" width="18" height="18" fill="currentColor" aria-hidden="true">
+          <path d="M12 .5C5.65.5.5 5.65.5 12c0 5.08 3.29 9.39 7.86 10.91.58.11.79-.25.79-.55v-2.17c-3.2.7-3.88-1.37-3.88-1.37-.53-1.34-1.3-1.7-1.3-1.7-1.06-.72.08-.71.08-.71 1.17.08 1.79 1.2 1.79 1.2 1.04 1.78 2.73 1.27 3.4.97.1-.75.41-1.27.74-1.56-2.55-.29-5.24-1.28-5.24-5.7 0-1.26.45-2.29 1.19-3.1-.12-.29-.52-1.46.11-3.05 0 0 .97-.31 3.18 1.18a11 11 0 0 1 5.8 0c2.21-1.49 3.18-1.18 3.18-1.18.63 1.59.23 2.76.11 3.05.74.81 1.19 1.84 1.19 3.1 0 4.43-2.69 5.41-5.25 5.69.42.36.79 1.07.79 2.16v3.2c0 .31.21.67.8.55 4.56-1.52 7.85-5.83 7.85-10.91C23.5 5.65 18.35.5 12 .5z"/>
+        </svg>
+        <span>github.com/DeepTempo/socbench</span>
+        <span class="cta-arrow" aria-hidden="true">&rarr;</span>
+      </a>
+    </div>
+    <div class="footer-origin">
+      <div class="footer-origin-label">Built with</div>
+      <div class="footer-origin-logos">
+        <a href="https://deeptempo.ai" target="_blank" rel="noopener" class="footer-origin-item" aria-label="DeepTempo">
+          <img src="../img/deeptempo-logo.png" alt="DeepTempo" />
+          <span class="footer-origin-caption">deeptempo.ai <span aria-hidden="true">&#8599;</span></span>
+        </a>
+        <a href="https://github.com/Vigil-SOC/vigil" target="_blank" rel="noopener" class="footer-origin-item" aria-label="Vigil">
+          <img src="../img/vigil-logo.png" alt="Vigil" />
+          <span class="footer-origin-caption">Vigil-SOC/vigil <span aria-hidden="true">&#8599;</span></span>
+        </a>
+      </div>
+    </div>
+  </div>
+  <div class="footer-bottom">
+    <span>SOCBench &middot; open benchmark for AI in cybersecurity operations</span>
+    <span>Apache 2.0</span>
+  </div>
+</footer>
+
+</body>
+</html>

--- a/src/socbench/patchloop/.gitignore
+++ b/src/socbench/patchloop/.gitignore
@@ -1,0 +1,6 @@
+node_modules/
+dist/
+build/
+*.tsbuildinfo
+remediation_result.json
+.DS_Store

--- a/src/socbench/patchloop/LICENSE
+++ b/src/socbench/patchloop/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Sam Armstrong
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/src/socbench/patchloop/README.md
+++ b/src/socbench/patchloop/README.md
@@ -1,0 +1,166 @@
+# patchloop
+
+A verification-loop remediation harness for security findings: propose a patch, **verify it with the same machinery that raised the alert**, feed the verbatim failure back to the model, and retry — up to a small bounded number of attempts.
+
+```
+Finding (CVE / SAST / pentest)
+        │
+        ▼
+   ┌─────────┐     kind: cve ──► CVE patching harness
+   │ Router  │────►kind: pentest ──► PoC-backed harness
+   └─────────┘     kind: ...  ──► your harness
+        │
+        ▼
+┌──────────────────────── RemediationHarness ────────────────────────┐
+│                                                                    │
+│   propose patch ──► apply ──► verify ──► pass? ──► verified diff   │
+│        ▲                        │                                  │
+│        │   verbatim failure     │ fail                             │
+│        └────────────────────────┘  (repair ON TOP of current       │
+│             (≤ N attempts)          patched state, not a reset)    │
+│                                                                    │
+│   verify = OrderedVerifier([ rescan,          ← cheap, default     │
+│                              regression tests,← don't break it     │
+│                              reproduction ])  ← expensive, PoC     │
+└────────────────────────────────────────────────────────────────────┘
+```
+
+
+
+## Why this exists
+
+Many benchmarks effectively evaluate zero-shot model performance, which makes as a proxy for intelligence and preventing brute-force gaming. But that hides the system-design result that matters in production: **a single round of execution feedback is worth more than every prompting and harness improvement combined.**
+
+Evidence, from [PatchEval](https://github.com/bytedance/PatchEval) runs with a direct-edit harness:
+
+
+| Setup                     | Strict score    | Note                                        |
+| ------------------------- | --------------- | ------------------------------------------- |
+| No feedback               | 77/230 = 33.5%  | GPT-5 w/ custom direct-edit harness         |
+| One verify-feedback round | 132/230 = 57.4% | **+25.2pp from the loop alone**, ~$0.17/CVE |
+
+
+(The feedback-round number is not leaderboard-comparable, but that's the point: the benchmark constraint excludes the thing that makes a production system work. In a SOC you generally have the detector that raised the alert; using it is free alpha.)
+
+The second observation: for a scoped task like "patch this finding", a specialized harness beats the standard general-purpose agent loop (read/write/edit/bash round-trips) on cost and predictability. One structured direct-edit request per attempt, with the intelligence budget spent on the verification loop instead.
+
+`patchloop` packages both observations as reusable scaffolding, with the benchmark's built-in evaluator replaced by the thing you actually have in a security operation: **your own detectors.**
+
+## The Verifier seam
+
+`Verifier` is the interface the project exists for. Ship your own; three production-shaped ones are included:
+
+
+| Verifier                 | Cost      | Pass condition                                                                      |
+| ------------------------ | --------- | ----------------------------------------------------------------------------------- |
+| `RescanVerifier`         | cheap     | re-run the detector that raised the finding; the finding id is no longer reported   |
+| `RegressionTestVerifier` | moderate  | project tests/build still pass (a patch that deletes the feature "passes" a rescan) |
+| `ReproductionVerifier`   | expensive | run the PoC / exploit; it **no longer works**                                       |
+
+
+`OrderedVerifier` chains them cheapest-first and fails fast: a patch that still trips the scanner never pays for a test run; a patch that breaks the build never pays for an exploit reproduction. Whatever check fails supplies the verbatim output for the repair round.
+
+A `Verifier` is one method returning an Effect. Because verification is a data-fetching effect, timeouts, interruption, and typed failures come from the runtime: `runCommand` kills the whole process group when its budget expires, so a hung scanner or PoC cannot outlive its verdict.
+
+```typescript
+import { Effect } from "effect"
+import {
+  DirectEditPatcher, Finding, GitWorkspace, OrderedVerifier,
+  RegressionTestVerifier, RemediationHarness, RescanVerifier,
+} from "patchloop"
+
+const harness = RemediationHarness({
+  patcher: DirectEditPatcher({ model: "anthropic/claude-sonnet-4.5" }),
+  verifier: OrderedVerifier([
+    RescanVerifier({ commandTemplate: "trivy fs --scanners vuln --quiet {workspace}" }),
+    RegressionTestVerifier({ commandTemplate: "make test" }),
+  ]),
+  maxAttempts: 3,
+})
+
+const finding = new Finding({
+  id: "CVE-2099-0001", kind: "cve",
+  title: "path traversal in download endpoint",
+  description: "...advisory text...",
+  locations: [], // empty → the patcher localizes from `git ls-files`
+})
+
+const program = Effect.gen(function* () {
+  const workspace = yield* GitWorkspace.make("/path/to/checkout")
+  const result = yield* harness.run(finding, workspace)
+  if (result.success) yield* openPullRequest(result.finalDiff) // your side of the fence
+})
+```
+
+
+
+## The Router seam
+
+In an AI SOC, an upstream triage agent decides a finding is auto-remediable and hands a normalized `Finding` to the router, which selects the specialized harness for that finding kind — instead of handing it to a general-purpose coding agent:
+
+```typescript
+const router = Router()
+router.register("cve", cveHarnessFactory)
+router.register("pentest", pentestHarnessFactory) // PoC-backed
+const result = yield* router.remediate(finding, workspace)
+```
+
+`Finding` is an Effect `Schema.Class`, so a finding arriving as untrusted JSON from a queue or webhook decodes with `decodeFinding` and real validation — a malformed payload is a typed parse error, not a landmine three stages downstream. An unroutable finding kind is a typed `UnroutedFindingError`.
+
+See `[examples/remediate-cve.ts](examples/remediate-cve.ts)` for a complete routed run. The registry is where new harness families land over time — dependency bumps, IaC misconfigurations, detection-rule tuning — each with its own patcher and its own verifier chain.
+
+## Why Effect
+
+The loop is a small state machine over fallible, interruptible I/O, which is exactly what Effect models well — and using it is a deliberate, opinionated choice, not decoration:
+
+- **Typed errors, not string-matched exceptions.** `PatchApplicationError`, `GenerationError`, `WorkspaceError`, and `CommandTimeoutError` are distinct tagged types. The loop reacts to each precisely: a generation error is retried, a bad-apply error resets the workspace, a genuine workspace/git failure aborts. None of that leans on parsing a `message`.
+- **A crashing verifier can never pass a patch.** The harness runs verification under `catchAllCause`, so *any* failure — typed error or unexpected defect — becomes a failed verdict carrying the pretty-printed cause. This is a safety property, and it is enforced by the type system rather than by remembering to wrap a `try`.
+- **Interruption-safe timeouts for free.** Verifier commands run detached and are killed by process group when their `Duration` budget expires.
+- **Schema-validated boundaries.** Findings and model output are decoded, not cast, so untrusted JSON fails loudly at the edge.
+
+
+
+## Loop rules (learned on the benchmark, encoded in `harness.ts`)
+
+1. **An empty patch is never a success.** The largest silent-failure bucket in early runs was "model returned nothing, harness recorded a submit."
+2. **Repair on top of the patched state.** The repair prompt carries the current (already patched) files, the cumulative diff, and the verbatim failure output. No reset between attempts.
+3. **Reset only when a patch fails to apply** — then the workspace no longer matches what the model believes, so start clean and say so in feedback.
+4. **A crashing verifier is a failure, never a pass.**
+5. **Bounded attempts** (default 3). The first feedback round buys the most.
+
+These are pinned by the test suite (`test/harness.test.ts`), which runs with no LLM and no scanners — scripted patchers and marker verifiers exercise the whole loop against a throwaway git repo:
+
+```bash
+npm install
+npm test
+```
+
+
+
+## Install / run
+
+```bash
+npm install
+export OPENROUTER_API_KEY=...   # reference patcher; any OpenAI-compatible endpoint works
+npx tsx examples/remediate-cve.ts --repo /path/to/checkout \
+    --finding examples/finding-cve.json
+```
+
+The reference `DirectEditPatcher` talks to OpenRouter by default (`baseUrl` is configurable). The `Patcher` interface is one method — swapping in your own provider, or a full agent, is a few lines.
+
+Requires Node 20+. Written in TypeScript on [Effect](https://effect.website); `npm run build` emits JS + `.d.ts` to `dist/`.
+
+Python scaffold (archived on the `python-scaffold` branch)
+
+```bash
+pip install -e .
+export OPENROUTER_API_KEY=...   # reference patcher; any OpenAI-compatible endpoint works
+python examples/remediate_cve.py --repo /path/to/checkout \
+    --finding examples/finding_cve.json
+```
+
+The reference `DirectEditPatcher` talks to OpenRouter by default (`base_url` is configurable). The `Patcher` protocol is one method — swapping in your own provider, or a full agent, is a few lines.
+
+## License
+
+MIT

--- a/src/socbench/patchloop/examples/finding-cve.json
+++ b/src/socbench/patchloop/examples/finding-cve.json
@@ -1,0 +1,12 @@
+{
+  "id": "CVE-2099-0001",
+  "kind": "cve",
+  "title": "Example: path traversal in file download endpoint",
+  "description": "The /download endpoint joins user-supplied filenames onto the served directory without normalization, allowing ../ traversal outside the intended root. Reported by the image scanner against the application layer.",
+  "detector": "trivy",
+  "locations": [],
+  "metadata": {
+    "rescan_command": "trivy fs --scanners vuln --quiet {workspace}",
+    "test_command": "make test"
+  }
+}

--- a/src/socbench/patchloop/examples/remediate-cve.ts
+++ b/src/socbench/patchloop/examples/remediate-cve.ts
@@ -1,0 +1,131 @@
+/**
+ * End-to-end example: route a CVE finding through the remediation harness.
+ *
+ * Usage:
+ *   export OPENROUTER_API_KEY=...
+ *   npx tsx examples/remediate-cve.ts --repo /path/to/checkout \
+ *       --finding examples/finding-cve.json \
+ *       --model anthropic/claude-sonnet-4.5
+ *
+ * The verifier chain here is the intended production shape: cheap rescan
+ * first, regression tests second, and (for PoC-backed findings) exploit
+ * reproduction last. Swap the command templates for your detector.
+ */
+import * as fs from "node:fs/promises"
+import { parseArgs } from "node:util"
+import { Effect } from "effect"
+
+import {
+  decodeFinding,
+  DirectEditPatcher,
+  type Finding,
+  GitWorkspace,
+  OrderedVerifier,
+  RegressionTestVerifier,
+  RemediationHarness,
+  ReproductionVerifier,
+  RescanVerifier,
+  Router,
+} from "../src/index.js"
+
+const buildRouter = (model: string): Router => {
+  const router = Router()
+
+  const str = (finding: Finding, key: string, fallback: string): string => {
+    const value = finding.metadata[key]
+    return typeof value === "string" ? value : fallback
+  }
+
+  router.register("cve", (finding) =>
+    RemediationHarness({
+      patcher: DirectEditPatcher({ model }),
+      verifier: OrderedVerifier([
+        RescanVerifier({
+          commandTemplate: str(
+            finding,
+            "rescan_command",
+            "trivy fs --scanners vuln --quiet {workspace}",
+          ),
+        }),
+        RegressionTestVerifier({
+          commandTemplate: str(finding, "test_command", "make test"),
+        }),
+      ]),
+      maxAttempts: 3,
+    }),
+  )
+
+  router.register("pentest", (finding) =>
+    RemediationHarness({
+      patcher: DirectEditPatcher({ model }),
+      verifier: OrderedVerifier([
+        RegressionTestVerifier({
+          commandTemplate: str(finding, "test_command", "make test"),
+        }),
+        ReproductionVerifier({
+          commandTemplate: str(finding, "poc_command", ""),
+        }),
+      ]),
+      maxAttempts: 3,
+    }),
+  )
+
+  return router
+}
+
+const main = Effect.gen(function* () {
+  const { values } = parseArgs({
+    options: {
+      repo: { type: "string" },
+      finding: { type: "string" },
+      model: { type: "string", default: "anthropic/claude-sonnet-4.5" },
+      out: { type: "string", default: "remediation_result.json" },
+    },
+  })
+  if (!values.repo || !values.finding) {
+    return yield* Effect.dieMessage(
+      "usage: remediate-cve.ts --repo <git checkout> --finding <finding.json>",
+    )
+  }
+
+  const raw = yield* Effect.promise(() => fs.readFile(values.finding!, "utf8"))
+  const finding = yield* decodeFinding(JSON.parse(raw))
+  const workspace = yield* GitWorkspace.make(values.repo)
+
+  const result = yield* buildRouter(values.model).remediate(finding, workspace)
+
+  yield* Effect.promise(() =>
+    fs.writeFile(
+      values.out,
+      JSON.stringify(
+        {
+          findingId: result.findingId,
+          success: result.success,
+          attempts: result.attempts.length,
+          finalDiff: result.finalDiff,
+          verdicts: result.attempts.map((a) => ({
+            attempt: a.index,
+            error: a.error,
+            verdict: a.verdict?.summary ?? null,
+          })),
+        },
+        null,
+        2,
+      ),
+    ),
+  )
+
+  const status = result.success ? "VERIFIED" : "NOT REMEDIATED"
+  yield* Effect.log(
+    `${finding.id}: ${status} after ${result.attempts.length} attempt(s); ` +
+      `details in ${values.out}`,
+  )
+  if (result.success) {
+    yield* Effect.log("Accepted diff:\n\n" + result.finalDiff)
+  }
+})
+
+Effect.runPromise(main).catch((error) => {
+  console.error(error)
+  process.exitCode = 1
+})

--- a/src/socbench/patchloop/package-lock.json
+++ b/src/socbench/patchloop/package-lock.json
@@ -1,0 +1,2209 @@
+{
+  "name": "patchloop",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "dependencies": {
+        "effect": "^3.22.0"
+      },
+      "devDependencies": {
+        "@types/node": "^26.1.1",
+        "tsx": "^4.23.1",
+        "typescript": "^7.0.2",
+        "vitest": "^4.1.10"
+      }
+    },
+    "node_modules/@emnapi/core": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.1.tgz",
+      "integrity": "sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.2",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.1.tgz",
+      "integrity": "sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.2.tgz",
+      "integrity": "sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.1.tgz",
+      "integrity": "sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.1.tgz",
+      "integrity": "sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.1.tgz",
+      "integrity": "sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.1.tgz",
+      "integrity": "sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.1.tgz",
+      "integrity": "sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.1.tgz",
+      "integrity": "sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.1.tgz",
+      "integrity": "sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.1.tgz",
+      "integrity": "sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.1.tgz",
+      "integrity": "sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.1.tgz",
+      "integrity": "sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.1.tgz",
+      "integrity": "sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.1.tgz",
+      "integrity": "sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.1.tgz",
+      "integrity": "sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.1.tgz",
+      "integrity": "sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.1.tgz",
+      "integrity": "sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.1.tgz",
+      "integrity": "sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.1.tgz",
+      "integrity": "sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.1.tgz",
+      "integrity": "sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.1.tgz",
+      "integrity": "sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.1.tgz",
+      "integrity": "sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.6.tgz",
+      "integrity": "sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@tybys/wasm-util": "^0.10.3"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "peerDependencies": {
+        "@emnapi/core": "^1.7.1",
+        "@emnapi/runtime": "^1.7.1"
+      }
+    },
+    "node_modules/@oxc-project/types": {
+      "version": "0.139.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.139.0.tgz",
+      "integrity": "sha512-r9gHphtCs+1M7J0pw6Sn/hh/Wpa/iQrOOkrNAlVLF/gHq+/CJmHIWKKUUhdWjcD6CIa8idarspCsASiXCXvFUw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
+      }
+    },
+    "node_modules/@rolldown/binding-android-arm64": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.1.5.tgz",
+      "integrity": "sha512-lZg8fqIv2v7FF237bwMgzGZEJvGL79/s5knJ/i6FmsGF4XXlzccZ4jb+TrFIxtSSxFtIpdsgrPZeMk1I9AFcyQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-arm64": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.1.5.tgz",
+      "integrity": "sha512-51Bnx9pNiMRKSUNtBfySkNJ9vMU9Hh3I1ozDd6gyPPYzaXCfnptUcEZxXGYFn+ul2dtcMUiqGR1Yai2K10uoTw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-x64": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.1.5.tgz",
+      "integrity": "sha512-Tm+gbfC0aHu1tBA/JvKQh32S0K6YgCHkiAF4/W6xX0K0RmNuc94VeK419dJoE65R5aRxmo+noZQSWrAMF6yb6g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-freebsd-x64": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.1.5.tgz",
+      "integrity": "sha512-JMzDKCCXq93YccG5gz3hvOs1oXRKAf0XYpfOS88e+wZrC8Iugj6j68867vrYZkvpDDpKn/KoKORThmchMpF6TA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.1.5.tgz",
+      "integrity": "sha512-uML21j2K5TfPGutKxub+M+nLjZIrWjXQ5Grx4lCe/nimTj9B4L63zHpjXLl4y0L3mcm2htEQIb06oCG/szerNw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-gnu": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.1.5.tgz",
+      "integrity": "sha512-navSiuTMogvnQoZoM/v+l3ZWo50/NTwSHSzheABx/RCnmUPaKwq9qSo4Br2OYRs21+Fz8uFqITZM3H4opOB0/Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-musl": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.1.5.tgz",
+      "integrity": "sha512-lAryqH7IteztmCXQXk0etKj4wBQ7Gx5S6LjKhsgp9zb8I5bsuvU/2llH1hDQcjsFeqIsovMVN339/8pUDDBXxA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-ppc64-gnu": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.1.5.tgz",
+      "integrity": "sha512-fsK/sNBnxzBlL4O1JNrZakVQxPspqpED5dLtNsZS9oOKmtSpdNIzxH2kkol5HYTWJN47sE20ztMJPxfZ89qGOg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-s390x-gnu": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.1.5.tgz",
+      "integrity": "sha512-gLYb4BIadlfTOYT5gO503n8zQjXflgzpD0FcyKh0Mzx3rqCZKnHoJWV9xe1KXUJ5lx2JfcSHr/mhzS0PC/McAA==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-gnu": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.1.5.tgz",
+      "integrity": "sha512-FjcpEKUyJygHgs1o50VYNvkt5+7Le/VEdYt0AkRpkL33MnyQfwr8l5mXwMmfmTbyMPr5vJLC+8/Gd9gXnwU1QQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-musl": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.1.5.tgz",
+      "integrity": "sha512-Me+PfPI2TMeOQk0gYWfLQZtTktrmzbr8cDboqX83XKc7UrgAi55gF+2dUkWdxd19n55Essp2yeca+O9N5rBxHg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-openharmony-arm64": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.1.5.tgz",
+      "integrity": "sha512-yc5WrLzXks6zCQfn9Oxr8pORKyl/pF+QjHmW/Qx3qu0oyrrNC+y2JLTU1E2rcWYAmzlnqngWXHQjy51VzW70Vw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.1.5.tgz",
+      "integrity": "sha512-VbQGPX2b4r48TAMIM2cjgluIM1HYutm4pcTEJsle7iEP7sB1dFqtPLBVbdLAZCxy1txCcPxf4QFf4v8uvltPqA==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "1.11.1",
+        "@emnapi/runtime": "1.11.1",
+        "@napi-rs/wasm-runtime": "^1.1.6"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-arm64-msvc": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.1.5.tgz",
+      "integrity": "sha512-gHv82k63z4qpV5+Q1y/12KrK0ltWBukVDI8nZcbT7Tt/ZlOIVwppazneq0F93oDxTo3IgAMEDIoQh3E2n6mVsw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-x64-msvc": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.1.5.tgz",
+      "integrity": "sha512-tTZuDBPw85tEN5PQi1pnEBzDy0Z49HtScLAbD5t6hyeU92A95pRWaSMw1GZZi/RwgSgUIl0xrSlXIT/9QzvYSA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/pluginutils": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.1.tgz",
+      "integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "license": "MIT"
+    },
+    "node_modules/@tybys/wasm-util": {
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.3.tgz",
+      "integrity": "sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "26.1.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.1.1.tgz",
+      "integrity": "sha512-nxAkRSVkN1Y0JC1W8ky/fTfkGsMmcrRsbx+3XoZE+rMOX71kLYTV7fLXpqud1GpbpP5TuffXFqfX7fH2GgZREw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~8.3.0"
+      }
+    },
+    "node_modules/@typescript/typescript-aix-ppc64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-aix-ppc64/-/typescript-aix-ppc64-7.0.2.tgz",
+      "integrity": "sha512-MTKKkWB7p/0E9xi1d1tHtZ5PiLkGEMIq88pK2CubZjOsLtYTLqhgIgi6zepFa+9GHZ6h05NMCkQxGKiPXMxXtQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-darwin-arm64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-darwin-arm64/-/typescript-darwin-arm64-7.0.2.tgz",
+      "integrity": "sha512-gowzar9MwS/aRWp6f3a4KUqzRjAZjOsmGNCM6LcTgXum+dBfgsBVMN+AgvOCCbguXyick6LJhpBszxMebJ8syA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-darwin-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-darwin-x64/-/typescript-darwin-x64-7.0.2.tgz",
+      "integrity": "sha512-SZ9xZInqApNlNGc9s0W1VSsktYSOe9cFqNOIqmN1Gs8SmkjKZYFt017G4VwPxASInODuAdbTW7sXiFUf893RgA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-freebsd-arm64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-freebsd-arm64/-/typescript-freebsd-arm64-7.0.2.tgz",
+      "integrity": "sha512-W5NH4y/J0plIIS5b2xvTEkU7JFxyqdMAOgf+Ilhl0vHQXKO5dZoxd+C/jEtq56c4F3wk71RB4BMRQ2XdI+bwYQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-freebsd-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-freebsd-x64/-/typescript-freebsd-x64-7.0.2.tgz",
+      "integrity": "sha512-UMGDx5sTpzNw3WiPebH7l90IWfJggEd+egHt/q6p7/Cm3zqoV7VxkGXt+3DxPIw8CcmvAB0j3sVVfbhX+M4Tpw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-arm": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-arm/-/typescript-linux-arm-7.0.2.tgz",
+      "integrity": "sha512-gffT3xPz9sR7j/YJExkyPntrI0P2EP9XbOyWzth2/Gs0RstK+90RBcO0ncXoXy/beYll1SXw846Nf2zdnEz0QQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-arm64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-arm64/-/typescript-linux-arm64-7.0.2.tgz",
+      "integrity": "sha512-Qh4eU4/y3yDjnfjjyPYihMj5/ODIlmt+Bzu17OI+fiSRDW57QmU5SiN63exPRNJPKUzcc1INa1NXdrJ+MqHjUQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-loong64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-loong64/-/typescript-linux-loong64-7.0.2.tgz",
+      "integrity": "sha512-uEHck9i8hoAzXPiYRib1O7miOnz23SxIeVl6F4LXox+qov1K35jHcEW6VHKvZI+pyvl7fZEP4MCU5LYvIq1GuQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-mips64el": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-mips64el/-/typescript-linux-mips64el-7.0.2.tgz",
+      "integrity": "sha512-R4KvAMnE43W5Qeqb0Ly56O3mWMWIAgsMyz36DCaycd5nbg/9kzm0liw3JocfRqyJY0KPmzFjbswozXyW0DnIYA==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-ppc64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-ppc64/-/typescript-linux-ppc64-7.0.2.tgz",
+      "integrity": "sha512-DORx5b3sd/4S7eayxm4FQv+A7CrkUIGRaHiwI8oiHTAI1fAPWhF4J0vAlkC8biAlHSVVwxMQ3tjZ2/DVbnQiiA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-riscv64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-riscv64/-/typescript-linux-riscv64-7.0.2.tgz",
+      "integrity": "sha512-wf0jqEDOjrPRnKwYRyyJDRo11KMbvMFrU+q4zqKyChODBzvlkbhNQfKvLxQCcwTpdDaXSHZTVuh0JoCrKCUMHQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-s390x": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-s390x/-/typescript-linux-s390x-7.0.2.tgz",
+      "integrity": "sha512-IkwJc3L7yhytWd/ewjyxNDfOmswCm9GWMJT/ue/dU4aZNbwZeYAetq42VyLmsmSjvoX7z74X6ZaYCtzAr0EuGw==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-x64/-/typescript-linux-x64-7.0.2.tgz",
+      "integrity": "sha512-EYdf2cNg7rgCWJnxCdJ+F3V39O8ihb37eHAu1LK8oAFizgTQbPOK7zHHXbPt8rX24COqODXeI3sIf0fCXG7H/A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-netbsd-arm64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-netbsd-arm64/-/typescript-netbsd-arm64-7.0.2.tgz",
+      "integrity": "sha512-+polYF4MF04aPpO5FTkHran9yUQDSXqy5GiSDKpsll5jy3l3+g9QLhpf39T+ePtefhXLOGrLl0QIjkQP6VnelA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-netbsd-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-netbsd-x64/-/typescript-netbsd-x64-7.0.2.tgz",
+      "integrity": "sha512-8YIT0EHM/3dq10ZOVF/A7pc/YSMtbcecct4rWtexrnSCHOPcpC2KTLXfTCR6vDpnSiY12heNb1GiN/wu+T/FyA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-openbsd-arm64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-openbsd-arm64/-/typescript-openbsd-arm64-7.0.2.tgz",
+      "integrity": "sha512-APT8+ClYnuYm1u9+kgGXoMj2VzWzcymwh2gNSQVySHfkRDGOTVkoWLjCmOQSaO+PoqQ57B0flRp9SA+7GnnkzQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-openbsd-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-openbsd-x64/-/typescript-openbsd-x64-7.0.2.tgz",
+      "integrity": "sha512-yX7s+Q0Dln0Dt9tEzZsAjXXR/+ytBM7AlglaqyeMPxQszJ1JhlJdZ6jLA+IzldHtflX81em7lDao1xXu+aRRkg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-sunos-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-sunos-x64/-/typescript-sunos-x64-7.0.2.tgz",
+      "integrity": "sha512-dLJDGaLZ1D4HPQn62u1n8mBDkJREwMsAkCdkwd4Ieqw+x3TUyTsqY0YiBCtE6H6OzzgGk3iuZ3vFWRS+E8/d1g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-win32-arm64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-win32-arm64/-/typescript-win32-arm64-7.0.2.tgz",
+      "integrity": "sha512-Gyl1Vy6OsWesLzmq+EP0Fb7b4Nid5232AvcA2SFcdYreldpNtYFFofPjnt62y9hQy7VTaZp65ICJjuAQRaVcIQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-win32-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-win32-x64/-/typescript-win32-x64-7.0.2.tgz",
+      "integrity": "sha512-0BQ3HkAHHlKLSp1qRvf3SUhGpGsDuhB/jgFw75guyqbxJqEaS0Cw/VFO8i2nHglJUzQCRtMMR/IBAKE3ETMC4g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.10.tgz",
+      "integrity": "sha512-YsCn+qAk1GWjQOWFEsEcL2gNQ0zmVmQu3T03qP6UyjhtmdtwtbuI+DASn/7iQB3HGTXkdBwGddzxPlmiql5vlA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.10.tgz",
+      "integrity": "sha512-v0xaezt+DKEmKfaxg133ldzADrwLGd7Ze1MfQQTYfvs8OqZIwbxyxaYURivwV7sWy5fqn3rH5uOrSp07bp44Ow==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.10",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.10.tgz",
+      "integrity": "sha512-W1HsjSH4MXQ9YfmmhLAoIYf1HRfekQCGngeIgcei6MP5QQGWUe0gkopdZQaVCFO+JDJMrAJGwa5pRpNpvy4P8Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.10.tgz",
+      "integrity": "sha512-IKI6kpIH+LmpROplyLwBBaCfMgOZOMsygVa6BARD6ahA04VRuJSa6OaVG7kRvSEMD870Vd91rSSw0eegtWyLGg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.10",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.10.tgz",
+      "integrity": "sha512-xRkfOT1qpTAi/Ti4Y1LtfRc3kEuqxGw59eN2jN9pRWMtS/XDevekhcFSqvQqjUNGksfjMJu3Y+oJ+4Ypn2OaJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.10.tgz",
+      "integrity": "sha512-PLf/Ugvoq5wO/b4rwYCR1h2PSIdXz7wnkQFMiUpLdtM7l6pqVFcQIBEHyT1+l+cj7mNwAfZHzqXqDyjvOuwbDw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.10.tgz",
+      "integrity": "sha512-fy9am/HWxbaGt/Sawrp90vt6Y6jQwf1RX77cz3uwoJwJVMli/e1IEwRPnMNJ7vKfPTwo0diXifkpPvwH9v7nGA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.10",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/effect": {
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/effect/-/effect-3.22.0.tgz",
+      "integrity": "sha512-jhYFe0zTlIRqYFrKTS+6luhmS/Tm0f+JLo0K9KUxvtFab1SUGEszQi2ehOP6QzAZvy831lDmTwwzvVDZSPNz3g==",
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.0.0",
+        "fast-check": "^3.23.1"
+      }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.3.1.tgz",
+      "integrity": "sha512-shc1dbU90Yl/xq1QrC7QRtfcwURZuVRfPhZbDoldJ1cn1gzDvBaBWlv0eFolj5+0znnPJz5TXLxsN77X/12KTA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/esbuild": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.1.tgz",
+      "integrity": "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.28.1",
+        "@esbuild/android-arm": "0.28.1",
+        "@esbuild/android-arm64": "0.28.1",
+        "@esbuild/android-x64": "0.28.1",
+        "@esbuild/darwin-arm64": "0.28.1",
+        "@esbuild/darwin-x64": "0.28.1",
+        "@esbuild/freebsd-arm64": "0.28.1",
+        "@esbuild/freebsd-x64": "0.28.1",
+        "@esbuild/linux-arm": "0.28.1",
+        "@esbuild/linux-arm64": "0.28.1",
+        "@esbuild/linux-ia32": "0.28.1",
+        "@esbuild/linux-loong64": "0.28.1",
+        "@esbuild/linux-mips64el": "0.28.1",
+        "@esbuild/linux-ppc64": "0.28.1",
+        "@esbuild/linux-riscv64": "0.28.1",
+        "@esbuild/linux-s390x": "0.28.1",
+        "@esbuild/linux-x64": "0.28.1",
+        "@esbuild/netbsd-arm64": "0.28.1",
+        "@esbuild/netbsd-x64": "0.28.1",
+        "@esbuild/openbsd-arm64": "0.28.1",
+        "@esbuild/openbsd-x64": "0.28.1",
+        "@esbuild/openharmony-arm64": "0.28.1",
+        "@esbuild/sunos-x64": "0.28.1",
+        "@esbuild/win32-arm64": "0.28.1",
+        "@esbuild/win32-ia32": "0.28.1",
+        "@esbuild/win32-x64": "0.28.1"
+      }
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.4.0.tgz",
+      "integrity": "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/fast-check": {
+      "version": "3.23.2",
+      "resolved": "https://registry.npmjs.org/fast-check/-/fast-check-3.23.2.tgz",
+      "integrity": "sha512-h5+1OzzfCC3Ef7VbtKdcv7zsstUQwUDlYpUTvjeUsJAssPgLn7QzbboPtL5ro04Mq0rPOsMzl7q5hIbRs2wD1A==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/dubzzz"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fast-check"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "pure-rand": "^6.1.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/lightningcss": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.32.0.tgz",
+      "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "detect-libc": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "optionalDependencies": {
+        "lightningcss-android-arm64": "1.32.0",
+        "lightningcss-darwin-arm64": "1.32.0",
+        "lightningcss-darwin-x64": "1.32.0",
+        "lightningcss-freebsd-x64": "1.32.0",
+        "lightningcss-linux-arm-gnueabihf": "1.32.0",
+        "lightningcss-linux-arm64-gnu": "1.32.0",
+        "lightningcss-linux-arm64-musl": "1.32.0",
+        "lightningcss-linux-x64-gnu": "1.32.0",
+        "lightningcss-linux-x64-musl": "1.32.0",
+        "lightningcss-win32-arm64-msvc": "1.32.0",
+        "lightningcss-win32-x64-msvc": "1.32.0"
+      }
+    },
+    "node_modules/lightningcss-android-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.32.0.tgz",
+      "integrity": "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.32.0.tgz",
+      "integrity": "sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.32.0.tgz",
+      "integrity": "sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-freebsd-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.32.0.tgz",
+      "integrity": "sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm-gnueabihf": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.32.0.tgz",
+      "integrity": "sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.32.0.tgz",
+      "integrity": "sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.32.0.tgz",
+      "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.32.0.tgz",
+      "integrity": "sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.32.0.tgz",
+      "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-arm64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.32.0.tgz",
+      "integrity": "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-x64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.32.0.tgz",
+      "integrity": "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.16",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
+      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/obug": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.4.tgz",
+      "integrity": "sha512-4a+OsYv9UktOJKE+l1A4OufDgdRF9PifWj+tJnHURo/P+WOxpG4GzUFL9qCalmWauao6ogiG+QvnCovwPoyAWA==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
+      }
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.19",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.19.tgz",
+      "integrity": "sha512-Mz8SaolMd8nB+G13WkORcxQKHZ/NE4xXevtkJHVuG+guo9/wYKlIMTKAqGdEmYOXR2ijPjTYNHssizdaVSUNdQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.12",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/pure-rand": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/pure-rand/-/pure-rand-6.1.0.tgz",
+      "integrity": "sha512-bVWawvoZoBYpp6yIoQtQXHZjmz35RSVHnUOTefl8Vcjr8snTPY1wnpSPMWekcFwbxI6gtmT7rSYPFvz71ldiOA==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/dubzzz"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fast-check"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/rolldown": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.1.5.tgz",
+      "integrity": "sha512-t9z29cJjXf/vxQ8dyhCSpt6H6aSwHTk8cT5I3iy6SMXuFpk5mB6PL6XfC8PCwrPTx93udwKUm9HRteAlTGBLiA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@oxc-project/types": "=0.139.0",
+        "@rolldown/pluginutils": "^1.0.0"
+      },
+      "bin": {
+        "rolldown": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "optionalDependencies": {
+        "@rolldown/binding-android-arm64": "1.1.5",
+        "@rolldown/binding-darwin-arm64": "1.1.5",
+        "@rolldown/binding-darwin-x64": "1.1.5",
+        "@rolldown/binding-freebsd-x64": "1.1.5",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.1.5",
+        "@rolldown/binding-linux-arm64-gnu": "1.1.5",
+        "@rolldown/binding-linux-arm64-musl": "1.1.5",
+        "@rolldown/binding-linux-ppc64-gnu": "1.1.5",
+        "@rolldown/binding-linux-s390x-gnu": "1.1.5",
+        "@rolldown/binding-linux-x64-gnu": "1.1.5",
+        "@rolldown/binding-linux-x64-musl": "1.1.5",
+        "@rolldown/binding-openharmony-arm64": "1.1.5",
+        "@rolldown/binding-wasm32-wasi": "1.1.5",
+        "@rolldown/binding-win32-arm64-msvc": "1.1.5",
+        "@rolldown/binding-win32-x64-msvc": "1.1.5"
+      }
+    },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.2.0.tgz",
+      "integrity": "sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.2.4.tgz",
+      "integrity": "sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
+      "license": "0BSD",
+      "optional": true
+    },
+    "node_modules/tsx": {
+      "version": "4.23.1",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.23.1.tgz",
+      "integrity": "sha512-GQHnkIfxyx1wYCOS/wonik5MVRZU9hi1TEZmzGZSCJB1y9YgoZ8H6itNE/u4suE+yLmOzuE4E5S4TZ/ZX2wcWQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.28.0"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-7.0.2.tgz",
+      "integrity": "sha512-8FYau96o3NKOhbjKi/qNvG/W5jhzxkbdm5sj9AbZ/5T5sWqn3hJgLfGx27sRKZWTvyzCP8dLRBTf5tBTSRVUNA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc"
+      },
+      "engines": {
+        "node": ">=16.20.0"
+      },
+      "optionalDependencies": {
+        "@typescript/typescript-aix-ppc64": "7.0.2",
+        "@typescript/typescript-darwin-arm64": "7.0.2",
+        "@typescript/typescript-darwin-x64": "7.0.2",
+        "@typescript/typescript-freebsd-arm64": "7.0.2",
+        "@typescript/typescript-freebsd-x64": "7.0.2",
+        "@typescript/typescript-linux-arm": "7.0.2",
+        "@typescript/typescript-linux-arm64": "7.0.2",
+        "@typescript/typescript-linux-loong64": "7.0.2",
+        "@typescript/typescript-linux-mips64el": "7.0.2",
+        "@typescript/typescript-linux-ppc64": "7.0.2",
+        "@typescript/typescript-linux-riscv64": "7.0.2",
+        "@typescript/typescript-linux-s390x": "7.0.2",
+        "@typescript/typescript-linux-x64": "7.0.2",
+        "@typescript/typescript-netbsd-arm64": "7.0.2",
+        "@typescript/typescript-netbsd-x64": "7.0.2",
+        "@typescript/typescript-openbsd-arm64": "7.0.2",
+        "@typescript/typescript-openbsd-x64": "7.0.2",
+        "@typescript/typescript-sunos-x64": "7.0.2",
+        "@typescript/typescript-win32-arm64": "7.0.2",
+        "@typescript/typescript-win32-x64": "7.0.2"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-8.3.0.tgz",
+      "integrity": "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/vite": {
+      "version": "8.1.5",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.1.5.tgz",
+      "integrity": "sha512-7ULLwsCdYx/nRyrpiEwvqb5TFHrMVZyBt+rg/OAXT7rgj/z+DtTDyKFeLAdDkubDVDKD8jOsndmy7m55XcfUsw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lightningcss": "^1.32.0",
+        "picomatch": "^4.0.5",
+        "postcss": "^8.5.17",
+        "rolldown": "~1.1.5",
+        "tinyglobby": "^0.2.17"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "@vitejs/devtools": "^0.3.0",
+        "esbuild": "^0.27.0 || ^0.28.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "@vitejs/devtools": {
+          "optional": true
+        },
+        "esbuild": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.10.tgz",
+      "integrity": "sha512-R9jUTe5S4Qb0HCd4TNqpC7oGcrMssMRGXLW80ubjWsW9VH5GF8y1Y0SFLY9AbqSk6nt0PnOx4H4WNJYZ13GUPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.10",
+        "@vitest/mocker": "4.1.10",
+        "@vitest/pretty-format": "4.1.10",
+        "@vitest/runner": "4.1.10",
+        "@vitest/snapshot": "4.1.10",
+        "@vitest/spy": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.10",
+        "@vitest/browser-preview": "4.1.10",
+        "@vitest/browser-webdriverio": "4.1.10",
+        "@vitest/coverage-istanbul": "4.1.10",
+        "@vitest/coverage-v8": "4.1.10",
+        "@vitest/ui": "4.1.10",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    }
+  }
+}

--- a/src/socbench/patchloop/package.json
+++ b/src/socbench/patchloop/package.json
@@ -1,0 +1,36 @@
+{
+  "name": "patchloop",
+  "version": "0.1.0",
+  "description": "Verification-loop remediation harness for security findings: propose a patch, verify with your own detector, feed failures back, retry.",
+  "type": "module",
+  "private": true,
+  "license": "MIT",
+  "engines": {
+    "node": ">=20"
+  },
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "scripts": {
+    "build": "tsc",
+    "test": "vitest run",
+    "example": "tsx examples/remediate-cve.ts"
+  },
+  "keywords": [
+    "security",
+    "remediation",
+    "cve",
+    "ai-soc",
+    "patching",
+    "agents",
+    "effect"
+  ],
+  "dependencies": {
+    "effect": "^3.22.0"
+  },
+  "devDependencies": {
+    "@types/node": "^26.1.1",
+    "tsx": "^4.23.1",
+    "typescript": "^7.0.2",
+    "vitest": "^4.1.10"
+  }
+}

--- a/src/socbench/patchloop/src/harness.ts
+++ b/src/socbench/patchloop/src/harness.ts
@@ -1,0 +1,204 @@
+/**
+ * The remediation loop: propose -> apply -> verify -> feed failure back -> repair.
+ *
+ * Loop rules, learned the expensive way on PatchEval full-230 runs:
+ *
+ * 1. An empty patch is never a success. Count it as a failed attempt and
+ *    retry with explicit feedback saying the previous response changed
+ *    nothing.
+ * 2. Repairs happen ON TOP of the current patched state, not from a reset.
+ *    The repair prompt gets the current files, the cumulative diff, and the
+ *    verbatim failure output. One round of this feedback was worth +25.2pp
+ *    strict on PatchEval — more than every prompting improvement combined.
+ * 3. Reset only when patch application itself fails (bad search text),
+ *    because then the workspace state no longer matches what the model
+ *    believes.
+ * 4. A crashing verifier is a failure, never a pass — every verifier error
+ *    (typed failure or defect) maps to a failed verdict via catchAllCause.
+ * 5. Bounded attempts. The first feedback round buys the most; returns fall
+ *    off fast after 2-3.
+ */
+import { Cause, type Either, Effect } from "effect"
+
+import {
+  type Attempt,
+  type EditPatch,
+  type Finding,
+  type GenerationError,
+  isEmptyPatch,
+  type PatchApplicationError,
+  type RemediationResult,
+  Verdict,
+  type WorkspaceError,
+} from "./models.js"
+import type { Verifier } from "./verify/base.js"
+import type { GitWorkspace } from "./workspace.js"
+
+export interface Patcher {
+  /**
+   * Propose exact edits for a finding. `feedback` is null on the first
+   * attempt; afterwards it carries the failure context assembled by the
+   * loop (verdict feedback + current diff).
+   */
+  readonly propose: (
+    finding: Finding,
+    workspace: GitWorkspace,
+    feedback: string | null,
+  ) => Effect.Effect<EditPatch, GenerationError>
+}
+
+export interface HarnessOptions {
+  readonly patcher: Patcher
+  readonly verifier: Verifier
+  readonly maxAttempts?: number
+}
+
+export interface RemediationHarness {
+  readonly run: (
+    finding: Finding,
+    workspace: GitWorkspace,
+  ) => Effect.Effect<RemediationResult, WorkspaceError>
+}
+
+const feedbackFor = (
+  failureOutput: string,
+  workspace: GitWorkspace,
+): Effect.Effect<string, WorkspaceError> =>
+  Effect.gen(function* () {
+    const diff = yield* workspace.diff()
+    const parts = ["## Verification failure output", failureOutput]
+    if (diff.trim() !== "") {
+      parts.push(
+        "## Your patch so far (currently applied to the workspace)",
+        diff,
+        "Repair on top of this state; edits apply to the current " +
+          "(already patched) file contents.",
+      )
+    }
+    return parts.join("\n\n")
+  })
+
+export const RemediationHarness = (
+  options: HarnessOptions,
+): RemediationHarness => {
+  const { patcher, verifier, maxAttempts = 3 } = options
+
+  const run = (
+    finding: Finding,
+    workspace: GitWorkspace,
+  ): Effect.Effect<RemediationResult, WorkspaceError> =>
+    Effect.gen(function* () {
+      const attempts: Array<Attempt> = []
+      let feedback: string | null = null
+
+      for (let i = 0; i < maxAttempts; i++) {
+        const proposed: Either.Either<EditPatch, GenerationError> =
+          yield* Effect.either(patcher.propose(finding, workspace, feedback))
+
+        if (proposed._tag === "Left") {
+          // provider/network errors are retryable
+          yield* Effect.logWarning(
+            `${finding.id} attempt ${i}: generation failed: ${proposed.left.message}`,
+          )
+          attempts.push({
+            index: i,
+            patch: null,
+            diff: yield* workspace.diff(),
+            verdict: null,
+            error: `generation error: ${proposed.left.message}`,
+          })
+          continue
+        }
+        const patch: EditPatch = proposed.right
+
+        if (isEmptyPatch(patch)) {
+          yield* Effect.logInfo(
+            `${finding.id} attempt ${i}: empty patch, retrying`,
+          )
+          attempts.push({
+            index: i,
+            patch,
+            diff: yield* workspace.diff(),
+            verdict: null,
+            error: "empty patch",
+          })
+          feedback = yield* feedbackFor(
+            "Your previous response contained no effective edits. " +
+              "You must change the code to remediate the finding.",
+            workspace,
+          )
+          continue
+        }
+
+        const applied: Either.Either<
+          void,
+          PatchApplicationError | WorkspaceError
+        > = yield* Effect.either(workspace.apply(patch))
+        if (applied._tag === "Left") {
+          if (applied.left._tag === "WorkspaceError") return yield* applied.left
+          yield* Effect.logInfo(
+            `${finding.id} attempt ${i}: patch failed to apply: ${applied.left.message}`,
+          )
+          yield* workspace.reset()
+          attempts.push({
+            index: i,
+            patch,
+            diff: "",
+            verdict: null,
+            error: `apply error: ${applied.left.message}`,
+          })
+          feedback =
+            `Your previous edits failed to apply: ${applied.left.message}\n` +
+            "The workspace has been reset to the original code. " +
+            "Search text must match the current file content exactly and uniquely."
+          continue
+        }
+
+        // A broken verifier must never pass a patch: any typed error or
+        // defect becomes a failed verdict carrying the pretty-printed cause.
+        const verdict = yield* verifier.verify(finding, workspace).pipe(
+          Effect.catchAllCause((cause) =>
+            Effect.succeed(
+              Verdict({
+                passed: false,
+                verifier: verifier.name,
+                summary: `verifier crashed: ${Cause.pretty(cause)}`,
+                feedback: `Verification infrastructure error: ${Cause.pretty(cause)}`,
+              }),
+            ),
+          ),
+        )
+        const diff = yield* workspace.diff()
+        attempts.push({ index: i, patch, diff, verdict, error: "" })
+
+        if (verdict.passed) {
+          yield* Effect.logInfo(
+            `${finding.id} attempt ${i}: verified (${verdict.summary})`,
+          )
+          return {
+            findingId: finding.id,
+            success: true,
+            attempts,
+            finalDiff: diff,
+          } satisfies RemediationResult
+        }
+
+        yield* Effect.logInfo(
+          `${finding.id} attempt ${i}: verification failed (${verdict.summary})`,
+        )
+        feedback = yield* feedbackFor(
+          verdict.feedback !== "" ? verdict.feedback : verdict.summary,
+          workspace,
+        )
+      }
+
+      return {
+        findingId: finding.id,
+        success: false,
+        attempts,
+        finalDiff: yield* workspace.diff(),
+      } satisfies RemediationResult
+    })
+
+  return { run }
+}

--- a/src/socbench/patchloop/src/index.ts
+++ b/src/socbench/patchloop/src/index.ts
@@ -1,0 +1,50 @@
+/** patchloop: a verification-loop remediation harness for security findings. */
+
+export {
+  type HarnessOptions,
+  type Patcher,
+  RemediationHarness,
+} from "./harness.js"
+export {
+  type Attempt,
+  CommandTimeoutError,
+  type CostHint,
+  decodeEditPatch,
+  decodeFinding,
+  Edit,
+  EditPatch,
+  Finding,
+  FindingKind,
+  GenerationError,
+  isEmptyPatch,
+  PatchApplicationError,
+  type RemediationResult,
+  UnroutedFindingError,
+  Verdict,
+  WorkspaceError,
+} from "./models.js"
+export {
+  DEFAULT_BASE_URL,
+  DirectEditPatcher,
+  type DirectEditOptions,
+} from "./patcher.js"
+export { type HarnessFactory, Router } from "./router.js"
+export {
+  type CommandResult,
+  MAX_FEEDBACK_CHARS,
+  renderCommand,
+  runCommand,
+  truncateFeedback,
+  type Verifier,
+} from "./verify/base.js"
+export { OrderedVerifier } from "./verify/composite.js"
+export {
+  RegressionTestVerifier,
+  type RegressionOptions,
+} from "./verify/regression.js"
+export {
+  ReproductionVerifier,
+  type ReproductionOptions,
+} from "./verify/reproduce.js"
+export { RescanVerifier, type RescanOptions } from "./verify/rescan.js"
+export { GitWorkspace } from "./workspace.js"

--- a/src/socbench/patchloop/src/models.ts
+++ b/src/socbench/patchloop/src/models.ts
@@ -1,0 +1,145 @@
+/**
+ * Core data types shared across the harness.
+ *
+ * A `Finding` is the normalized input a SOC router hands to a remediation
+ * harness: enough to locate the code, and enough to re-run whatever raised
+ * the alert. It is an Effect Schema class so untrusted JSON (from a queue,
+ * a webhook, a case-management export) decodes with real validation instead
+ * of a cast. Everything else (attempts, verdicts, results) is the loop's
+ * audit trail — plain data, safe to serialize into your case system.
+ */
+import { Data, Schema } from "effect"
+
+/** Coarse routing key. Extend freely; the router matches on the value. */
+export const FindingKind = Schema.Literal(
+  "cve",     // known-vulnerability finding (SCA / image scan)
+  "sast",    // static-analysis finding
+  "pentest", // bug-bounty / pentest style, usually PoC-backed
+  "custom",
+)
+export type FindingKind = typeof FindingKind.Type
+
+/**
+ * Normalized security finding.
+ *
+ * `locations` is optional on purpose: with locations you are in the
+ * "oracle" setting, without them the patcher must localize itself
+ * (measurably harder — budget more attempts).
+ */
+export class Finding extends Schema.Class<Finding>("Finding")({
+  id: Schema.String, // e.g. "CVE-2023-1234" or detector finding id
+  kind: FindingKind,
+  title: Schema.String,
+  description: Schema.String, // the alert body / advisory text
+  detector: Schema.optionalWith(Schema.String, { default: () => "" }),
+  locations: Schema.optionalWith(Schema.Array(Schema.String), {
+    default: () => [], // repo-relative paths
+  }),
+  metadata: Schema.optionalWith(
+    Schema.Record({ key: Schema.String, value: Schema.Unknown }),
+    { default: () => ({}) },
+  ),
+}) {}
+
+export const decodeFinding = Schema.decodeUnknown(Finding)
+
+/**
+ * One exact search/replace edit. Exact-match edits (not free-form diffs)
+ * are deliberate: they fail loudly when the model hallucinates context,
+ * instead of fuzzy-applying garbage. An empty `search` with a non-empty
+ * `replace` creates a new file.
+ */
+export const Edit = Schema.Struct({
+  path: Schema.String,
+  search: Schema.optionalWith(Schema.String, { default: () => "" }),
+  replace: Schema.optionalWith(Schema.String, { default: () => "" }),
+})
+export type Edit = typeof Edit.Type
+
+/** A concrete change set proposed by a patcher. */
+export const EditPatch = Schema.Struct({
+  edits: Schema.optionalWith(Schema.Array(Edit), { default: () => [] }),
+  rationale: Schema.optionalWith(Schema.String, { default: () => "" }),
+})
+export type EditPatch = typeof EditPatch.Type
+
+export const decodeEditPatch = Schema.decodeUnknown(EditPatch)
+
+export const isEmptyPatch = (patch: EditPatch): boolean =>
+  patch.edits.length === 0 || patch.edits.every((e) => e.search === e.replace)
+
+export type CostHint = "cheap" | "moderate" | "expensive"
+
+/**
+ * Outcome of one verification pass.
+ *
+ * `feedback` is the payload that makes the loop work: verbatim failing
+ * output (rescan report, PoC output, test failures) that gets fed back to
+ * the patcher. Empty feedback on failure wastes the retry.
+ */
+export interface Verdict {
+  readonly passed: boolean
+  readonly verifier: string // name of the verifier that produced this
+  readonly summary: string
+  readonly feedback: string // verbatim failure output, truncated by producer
+  readonly costHint: CostHint
+}
+
+export const Verdict = (
+  input: Pick<Verdict, "passed" | "verifier"> & Partial<Verdict>,
+): Verdict => ({
+  summary: "",
+  feedback: "",
+  costHint: "cheap",
+  ...input,
+})
+
+export interface Attempt {
+  readonly index: number
+  readonly patch: EditPatch | null
+  /** cumulative diff vs baseline after this attempt */
+  readonly diff: string
+  readonly verdict: Verdict | null
+  /** patch-application or generation error, if any */
+  readonly error: string
+}
+
+export interface RemediationResult {
+  readonly findingId: string
+  readonly success: boolean
+  readonly attempts: ReadonlyArray<Attempt>
+  /** cumulative diff of the accepted (or last) state */
+  readonly finalDiff: string
+}
+
+// ---------------------------------------------------------------------------
+// Typed errors. Tagged so callers can catch exactly what they mean to catch
+// (Effect.catchTag) instead of string-matching exception messages.
+// ---------------------------------------------------------------------------
+
+/** Edits could not be applied (bad search text, path escape, …). */
+export class PatchApplicationError extends Data.TaggedError(
+  "PatchApplicationError",
+)<{ readonly message: string }> {}
+
+/** Underlying git/filesystem operation failed. */
+export class WorkspaceError extends Data.TaggedError("WorkspaceError")<{
+  readonly message: string
+  readonly cause?: unknown
+}> {}
+
+/** Patch generation failed (provider error, unparseable model output, …). */
+export class GenerationError extends Data.TaggedError("GenerationError")<{
+  readonly message: string
+  readonly cause?: unknown
+}> {}
+
+/** A verifier command exceeded its time budget. */
+export class CommandTimeoutError extends Data.TaggedError(
+  "CommandTimeoutError",
+)<{ readonly command: string; readonly timeoutSeconds: number }> {}
+
+/** No harness is registered for a finding kind. */
+export class UnroutedFindingError extends Data.TaggedError(
+  "UnroutedFindingError",
+)<{ readonly kind: FindingKind; readonly registered: ReadonlyArray<string> }> {}

--- a/src/socbench/patchloop/src/patcher.ts
+++ b/src/socbench/patchloop/src/patcher.ts
@@ -1,0 +1,244 @@
+/**
+ * Reference LLM patcher: direct exact-edit generation, no agentic tool loop.
+ *
+ * Deliberately NOT a read/write/bash agent. For a scoped task like "patch
+ * this finding", one structured request per attempt is cheaper and more
+ * predictable than an open-ended tool-calling loop: on PatchEval full-230
+ * this shape ran at roughly $0.15-0.17/CVE. The intelligence budget goes to
+ * the verification loop instead (see harness.ts).
+ *
+ * Two-phase when locations are unknown:
+ * 1. localize: model picks candidate files from `git ls-files` output
+ * 2. edit: model sees the finding + numbered file contents, returns JSON
+ *    search/replace edits — decoded with Effect Schema, so malformed model
+ *    output is a typed GenerationError, not a mystery crash downstream.
+ *
+ * Any OpenAI-compatible chat-completions endpoint works (OpenRouter
+ * default); swap `request` for your provider of choice.
+ */
+import { Duration, Effect, Schema } from "effect"
+
+import type { Patcher } from "./harness.js"
+import {
+  decodeEditPatch,
+  type EditPatch,
+  type Finding,
+  GenerationError,
+} from "./models.js"
+import type { GitWorkspace } from "./workspace.js"
+
+export const DEFAULT_BASE_URL = "https://openrouter.ai/api/v1/chat/completions"
+
+const LocalizationResponse = Schema.Struct({
+  paths: Schema.Array(Schema.String),
+})
+
+export const extractJsonObject = (text: string): string => {
+  const start = text.indexOf("{")
+  const end = text.lastIndexOf("}")
+  if (start === -1 || end <= start) {
+    throw new Error("model response contained no JSON object")
+  }
+  return text.slice(start, end + 1)
+}
+
+const numbered = (content: string): string =>
+  content
+    .split("\n")
+    .map((line, i) => `${i + 1}\t${line}`)
+    .join("\n")
+
+export interface DirectEditOptions {
+  readonly model: string
+  readonly apiKeyEnv?: string
+  readonly baseUrl?: string
+  readonly requestTimeoutSeconds?: number
+  readonly maxLocalizedFiles?: number
+  readonly extraHeaders?: Readonly<Record<string, string>>
+}
+
+export const DirectEditPatcher = (options: DirectEditOptions): Patcher => {
+  const {
+    model,
+    apiKeyEnv = "OPENROUTER_API_KEY",
+    baseUrl = DEFAULT_BASE_URL,
+    requestTimeoutSeconds = 1200,
+    maxLocalizedFiles = 8,
+    extraHeaders = {},
+  } = options
+
+  const fail = (message: string, cause?: unknown) =>
+    new GenerationError(cause === undefined ? { message } : { message, cause })
+
+  // -- transport -------------------------------------------------------------
+
+  const request = (
+    system: string,
+    user: string,
+  ): Effect.Effect<string, GenerationError> =>
+    Effect.gen(function* () {
+      const apiKey = process.env[apiKeyEnv] ?? ""
+      if (apiKey === "") {
+        return yield* fail(`set ${apiKeyEnv} in the environment`)
+      }
+      const response = yield* Effect.tryPromise({
+        try: (signal) =>
+          fetch(baseUrl, {
+            method: "POST",
+            signal,
+            headers: {
+              Authorization: `Bearer ${apiKey}`,
+              "Content-Type": "application/json",
+              ...extraHeaders,
+            },
+            body: JSON.stringify({
+              model,
+              messages: [
+                { role: "system", content: system },
+                { role: "user", content: user },
+              ],
+            }),
+          }),
+        catch: (cause) => fail(`provider request failed: ${cause}`, cause),
+      }).pipe(
+        Effect.timeoutFail({
+          duration: Duration.seconds(requestTimeoutSeconds),
+          onTimeout: () =>
+            fail(`provider request timed out after ${requestTimeoutSeconds}s`),
+        }),
+      )
+      if (!response.ok) {
+        return yield* fail(`provider returned HTTP ${response.status}`)
+      }
+      const body = yield* Effect.tryPromise({
+        try: () => response.json() as Promise<any>,
+        catch: (cause) => fail("provider response was not JSON", cause),
+      })
+      const content: unknown = body?.choices?.[0]?.message?.content
+      if (typeof content !== "string" || content === "") {
+        return yield* fail("provider returned an empty completion")
+      }
+      return content
+    })
+
+  const parseWith = <A>(
+    decode: (input: unknown) => Effect.Effect<A, unknown>,
+    text: string,
+  ): Effect.Effect<A, GenerationError> =>
+    Effect.try({
+      try: () => JSON.parse(extractJsonObject(text)) as unknown,
+      catch: (cause) => fail(`unparseable model response: ${cause}`, cause),
+    }).pipe(
+      Effect.flatMap((json) =>
+        decode(json).pipe(
+          Effect.mapError((cause) =>
+            fail(`model response failed schema validation: ${cause}`, cause),
+          ),
+        ),
+      ),
+    )
+
+  // -- phases ------------------------------------------------------------------
+
+  const localize = (
+    finding: Finding,
+    workspace: GitWorkspace,
+  ): Effect.Effect<ReadonlyArray<string>, GenerationError> =>
+    Effect.gen(function* () {
+      const repoFiles = yield* workspace
+        .listFiles()
+        .pipe(
+          Effect.mapError((e) => fail(`cannot list repository files: ${e.message}`)),
+        )
+      const prompt = [
+        "Locate the files that must be inspected to fix this security finding.",
+        'Return one JSON object and nothing else: {"paths": ["relative/path", "..."]}',
+        `Choose at most ${maxLocalizedFiles} paths from the list below.`,
+        "",
+        `## Finding\n${finding.title}\n\n${finding.description}`,
+        "",
+        "## Repository files\n" + repoFiles.join("\n"),
+      ].join("\n")
+      const response = yield* request(
+        "You localize security vulnerabilities to source files.",
+        prompt,
+      )
+      const parsed = yield* parseWith(
+        Schema.decodeUnknown(LocalizationResponse),
+        response,
+      )
+      const known = new Set(repoFiles)
+      const valid = parsed.paths.filter((p) => known.has(p))
+      if (valid.length === 0) {
+        return yield* fail("localization returned no valid repository paths")
+      }
+      return valid.slice(0, maxLocalizedFiles)
+    })
+
+  const editPrompt = (
+    finding: Finding,
+    files: ReadonlyArray<readonly [string, string]>,
+    feedback: string | null,
+  ): string => {
+    const sections = [
+      "Fix the following security finding with the smallest correct change.",
+      "Return one JSON object and nothing else:",
+      '{"rationale": "one paragraph", "edits": [{"path": "...", ' +
+        '"search": "exact current text", "replace": "new text"}]}',
+      "Rules:",
+      "- search text must match the CURRENT file content exactly and uniquely",
+      "- do not include line-number prefixes in search or replace text",
+      '- to create a new file, use an empty "search"',
+      `\n## Finding ${finding.id}\n${finding.title}\n\n${finding.description}`,
+    ]
+    for (const [relPath, content] of files) {
+      sections.push(
+        `\n### Current file: ${relPath} (1-based line numbers shown; ` +
+          "do not include them in edits)\n```text\n" +
+          numbered(content) +
+          "\n```",
+      )
+    }
+    if (feedback !== null) {
+      sections.push(
+        "\n## Previous attempt failed verification\n" +
+          "Repair your patch so verification passes. The file contents " +
+          "above already include your previous edits.\n\n" +
+          feedback,
+      )
+    }
+    return sections.join("\n")
+  }
+
+  // -- Patcher interface ---------------------------------------------------------
+
+  const propose = (
+    finding: Finding,
+    workspace: GitWorkspace,
+    feedback: string | null,
+  ): Effect.Effect<EditPatch, GenerationError> =>
+    Effect.gen(function* () {
+      const paths =
+        finding.locations.length > 0
+          ? finding.locations
+          : yield* localize(finding, workspace)
+      const files: Array<readonly [string, string]> = []
+      for (const p of paths) {
+        if (yield* workspace.exists(p)) {
+          const content = yield* workspace
+            .read(p)
+            .pipe(Effect.mapError((e) => fail(e.message, e)))
+          files.push([p, content] as const)
+        }
+      }
+      const response = yield* request(
+        "You write minimal, correct security patches as exact " +
+          "search/replace edits. You never weaken tests or disable " +
+          "the vulnerable feature to make checks pass.",
+        editPrompt(finding, files, feedback),
+      )
+      return yield* parseWith(decodeEditPatch, response)
+    })
+
+  return { propose }
+}

--- a/src/socbench/patchloop/src/router.ts
+++ b/src/socbench/patchloop/src/router.ts
@@ -1,0 +1,54 @@
+/**
+ * Router: the SOC-side entry point.
+ *
+ * An upstream triage agent (or a human) decides "this finding should be
+ * auto-remediated" and hands a normalized Finding to the router. The router
+ * picks the specialized harness for that finding kind — it does NOT hand
+ * the finding to a general-purpose coding agent. Specialized harness +
+ * packaged verification is the whole point.
+ *
+ * This scaffold ships one harness family (code patching). The registry
+ * shape is where new ones land over time: dependency bumps, IaC
+ * misconfigurations, detection-rule tuning — each with its own patcher and
+ * its own verifiers.
+ */
+import { Effect } from "effect"
+
+import type { RemediationHarness } from "./harness.js"
+import {
+  type Finding,
+  type FindingKind,
+  type RemediationResult,
+  UnroutedFindingError,
+  type WorkspaceError,
+} from "./models.js"
+import type { GitWorkspace } from "./workspace.js"
+
+export type HarnessFactory = (finding: Finding) => RemediationHarness
+
+export interface Router {
+  readonly register: (kind: FindingKind, factory: HarnessFactory) => void
+  readonly remediate: (
+    finding: Finding,
+    workspace: GitWorkspace,
+  ) => Effect.Effect<RemediationResult, UnroutedFindingError | WorkspaceError>
+}
+
+export const Router = (): Router => {
+  const registry = new Map<FindingKind, HarnessFactory>()
+  return {
+    register: (kind, factory) => {
+      registry.set(kind, factory)
+    },
+    remediate: (finding, workspace) => {
+      const factory = registry.get(finding.kind)
+      if (factory === undefined) {
+        return new UnroutedFindingError({
+          kind: finding.kind,
+          registered: [...registry.keys()],
+        })
+      }
+      return factory(finding).run(finding, workspace)
+    },
+  }
+}

--- a/src/socbench/patchloop/src/verify/base.ts
+++ b/src/socbench/patchloop/src/verify/base.ts
@@ -1,0 +1,114 @@
+/**
+ * Verifier interface + shared command plumbing.
+ *
+ * This is the seam the whole project exists for. In benchmark form the
+ * verifier was PatchEval's evaluator; in a SOC it is whatever can
+ * independently confirm the finding is gone: a rescan of the original
+ * detector, the project's test suite, or a reproduction of the exploit.
+ * Implement `verify` and return a Verdict whose `feedback` carries verbatim
+ * failure output — that feedback is what the repair round runs on.
+ *
+ * Infrastructure failures are typed errors, not verdicts; the harness maps
+ * any verifier error to a FAILED verdict (a broken scanner must never pass
+ * a patch).
+ */
+import { spawn } from "node:child_process"
+import { Duration, Effect } from "effect"
+
+import {
+  CommandTimeoutError,
+  type Finding,
+  type Verdict,
+} from "../models.js"
+import type { GitWorkspace } from "../workspace.js"
+
+export const MAX_FEEDBACK_CHARS = 20_000
+
+export interface Verifier {
+  readonly name: string
+  readonly verify: (
+    finding: Finding,
+    workspace: GitWorkspace,
+  ) => Effect.Effect<Verdict, unknown>
+}
+
+/** Keep head and tail; failures usually live at the edges of output. */
+export const truncateFeedback = (
+  output: string,
+  limit: number = MAX_FEEDBACK_CHARS,
+): string => {
+  if (output.length <= limit) return output
+  const half = Math.floor(limit / 2)
+  return (
+    output.slice(0, half) +
+    `\n... [${output.length - limit} chars truncated] ...\n` +
+    output.slice(-half)
+  )
+}
+
+export interface CommandResult {
+  readonly exitCode: number
+  /** stdout followed by stderr, the way a human reads a failed run */
+  readonly output: string
+}
+
+/**
+ * Run a shell command in the workspace with a hard time budget.
+ *
+ * Interruption-safe by construction: the timeout interrupts the fiber and
+ * the cleanup effect kills the whole process group, so a hung scanner or
+ * PoC cannot outlive its verdict.
+ */
+export const runCommand = (
+  command: string,
+  workspace: GitWorkspace,
+  timeoutSeconds: number,
+): Effect.Effect<CommandResult, CommandTimeoutError> =>
+  Effect.async<CommandResult>((resume) => {
+    const child = spawn("sh", ["-c", command], {
+      cwd: workspace.root,
+      detached: true, // own process group, so cleanup kills grandchildren too
+    })
+    let stdout = ""
+    let stderr = ""
+    child.stdout.on("data", (chunk: Buffer) => (stdout += chunk.toString()))
+    child.stderr.on("data", (chunk: Buffer) => (stderr += chunk.toString()))
+    child.on("error", (error) =>
+      resume(Effect.succeed({ exitCode: 127, output: String(error) })),
+    )
+    child.on("close", (code) =>
+      resume(
+        Effect.succeed({
+          exitCode: code ?? 1,
+          output: stdout + (stderr ? "\n" + stderr : ""),
+        }),
+      ),
+    )
+    return Effect.sync(() => {
+      if (child.pid !== undefined && child.exitCode === null) {
+        try {
+          process.kill(-child.pid, "SIGKILL")
+        } catch {
+          child.kill("SIGKILL")
+        }
+      }
+    })
+  }).pipe(
+    Effect.timeoutFail({
+      duration: Duration.seconds(timeoutSeconds),
+      onTimeout: () => new CommandTimeoutError({ command, timeoutSeconds }),
+    }),
+  )
+
+const shellQuote = (value: string): string =>
+  "'" + value.replaceAll("'", `'\\''`) + "'"
+
+/** Substitute `{workspace}` and `{finding_id}` placeholders, shell-quoted. */
+export const renderCommand = (
+  template: string,
+  finding: Finding,
+  workspace: GitWorkspace,
+): string =>
+  template
+    .replaceAll("{workspace}", shellQuote(workspace.root))
+    .replaceAll("{finding_id}", shellQuote(finding.id))

--- a/src/socbench/patchloop/src/verify/composite.ts
+++ b/src/socbench/patchloop/src/verify/composite.ts
@@ -1,0 +1,52 @@
+/**
+ * Ordered verifier chain: cheapest first, fail fast, feedback from the
+ * first failure.
+ *
+ * The intended production shape:
+ *
+ *     OrderedVerifier([rescan, regressionTests, reproduction])
+ *
+ * A patch that still trips the detector never pays for a test run; a patch
+ * that breaks the build never pays for an exploit reproduction. The
+ * verdict's feedback comes from the check that failed, so the repair round
+ * always sees the earliest, cheapest actionable failure.
+ */
+import { Effect } from "effect"
+
+import { type Finding, Verdict } from "../models.js"
+import type { GitWorkspace } from "../workspace.js"
+import type { Verifier } from "./base.js"
+
+export const OrderedVerifier = (
+  verifiers: ReadonlyArray<Verifier>,
+  name = "ordered",
+): Verifier => {
+  if (verifiers.length === 0) {
+    throw new Error("OrderedVerifier requires at least one verifier")
+  }
+  return {
+    name,
+    verify: (finding: Finding, workspace: GitWorkspace) =>
+      Effect.gen(function* () {
+        const summaries: Array<string> = []
+        for (const verifier of verifiers) {
+          const verdict = yield* verifier.verify(finding, workspace)
+          summaries.push(`${verdict.verifier}: ${verdict.summary}`)
+          if (!verdict.passed) {
+            return Verdict({
+              passed: false,
+              verifier: name,
+              summary: summaries.join("; "),
+              feedback: `[failed check: ${verdict.verifier}]\n${verdict.feedback}`,
+              costHint: verdict.costHint,
+            })
+          }
+        }
+        return Verdict({
+          passed: true,
+          verifier: name,
+          summary: summaries.join("; "),
+        })
+      }),
+  }
+}

--- a/src/socbench/patchloop/src/verify/regression.ts
+++ b/src/socbench/patchloop/src/verify/regression.ts
@@ -1,0 +1,69 @@
+/**
+ * Regression verifier: the patch must not break the project.
+ *
+ * Closing the finding is necessary, not sufficient — a patch that deletes
+ * the vulnerable feature "passes" a rescan. Run the project's build/tests
+ * as a regression gate alongside the security check.
+ */
+import { Effect } from "effect"
+
+import { type Finding, Verdict } from "../models.js"
+import type { GitWorkspace } from "../workspace.js"
+import {
+  renderCommand,
+  runCommand,
+  truncateFeedback,
+  type Verifier,
+} from "./base.js"
+
+export interface RegressionOptions {
+  /** e.g. "make test" or "npm test" */
+  readonly commandTemplate: string
+  readonly timeoutSeconds?: number
+  readonly name?: string
+}
+
+export const RegressionTestVerifier = (options: RegressionOptions): Verifier => {
+  const {
+    commandTemplate,
+    timeoutSeconds = 1800,
+    name = "regression-tests",
+  } = options
+  return {
+    name,
+    verify: (finding: Finding, workspace: GitWorkspace) =>
+      runCommand(
+        renderCommand(commandTemplate, finding, workspace),
+        workspace,
+        timeoutSeconds,
+      ).pipe(
+        Effect.map((result) =>
+          result.exitCode === 0
+            ? Verdict({
+                passed: true,
+                verifier: name,
+                costHint: "moderate",
+                summary: "regression tests pass",
+              })
+            : Verdict({
+                passed: false,
+                verifier: name,
+                costHint: "moderate",
+                summary: `regression tests fail (exit ${result.exitCode})`,
+                feedback: truncateFeedback(result.output),
+              }),
+        ),
+        Effect.catchTag("CommandTimeoutError", (e) =>
+          Effect.succeed(
+            Verdict({
+              passed: false,
+              verifier: name,
+              costHint: "moderate",
+              summary: `test suite timed out after ${e.timeoutSeconds}s`,
+              feedback: `Regression command timed out: ${e.command}`,
+            }),
+          ),
+        ),
+      ),
+  }
+}

--- a/src/socbench/patchloop/src/verify/reproduce.ts
+++ b/src/socbench/patchloop/src/verify/reproduce.ts
@@ -1,0 +1,87 @@
+/**
+ * Reproduction verifier: run the exploit / PoC and expect it to stop working.
+ *
+ * The expensive, high-confidence option — the natural fit for pentest and
+ * bug-bounty style findings that ship with reproduction steps. Semantics
+ * are inverted relative to a test suite: the patch passes when the exploit
+ * FAILS.
+ */
+import { Effect } from "effect"
+
+import { type Finding, Verdict } from "../models.js"
+import type { GitWorkspace } from "../workspace.js"
+import {
+  renderCommand,
+  runCommand,
+  truncateFeedback,
+  type Verifier,
+} from "./base.js"
+
+export interface ReproductionOptions {
+  /** e.g. "python3 poc/exploit.py --target {workspace}" */
+  readonly commandTemplate: string
+  /**
+   * - "exploit-nonzero" (default): PoC exits nonzero after the patch.
+   * - "marker-absent": `successMarker` no longer appears in PoC output
+   *   (for PoCs that exit 0 either way and print e.g. "VULNERABLE").
+   */
+  readonly passWhen?: "exploit-nonzero" | "marker-absent"
+  readonly successMarker?: string
+  readonly timeoutSeconds?: number
+  readonly name?: string
+}
+
+export const ReproductionVerifier = (options: ReproductionOptions): Verifier => {
+  const {
+    commandTemplate,
+    passWhen = "exploit-nonzero",
+    successMarker = "",
+    timeoutSeconds = 900,
+    name = "reproduce",
+  } = options
+  if (passWhen === "marker-absent" && successMarker === "") {
+    throw new Error("marker-absent requires successMarker")
+  }
+  return {
+    name,
+    verify: (finding: Finding, workspace: GitWorkspace) =>
+      runCommand(
+        renderCommand(commandTemplate, finding, workspace),
+        workspace,
+        timeoutSeconds,
+      ).pipe(
+        Effect.map((result) => {
+          const exploited =
+            passWhen === "marker-absent"
+              ? result.output.includes(successMarker)
+              : result.exitCode === 0
+          return exploited
+            ? Verdict({
+                passed: false,
+                verifier: name,
+                costHint: "expensive",
+                summary: "exploit still reproduces against patched code",
+                feedback: truncateFeedback(result.output),
+              })
+            : Verdict({
+                passed: true,
+                verifier: name,
+                costHint: "expensive",
+                summary: "exploit no longer reproduces",
+              })
+        }),
+        // A hanging PoC is ambiguous — never count it as a pass.
+        Effect.catchTag("CommandTimeoutError", (e) =>
+          Effect.succeed(
+            Verdict({
+              passed: false,
+              verifier: name,
+              costHint: "expensive",
+              summary: `PoC timed out after ${e.timeoutSeconds}s (ambiguous, treated as fail)`,
+              feedback: `Reproduction command timed out: ${e.command}`,
+            }),
+          ),
+        ),
+      ),
+  }
+}

--- a/src/socbench/patchloop/src/verify/rescan.ts
+++ b/src/socbench/patchloop/src/verify/rescan.ts
@@ -1,0 +1,83 @@
+/**
+ * Rescan verifier: re-run the detector that raised the finding.
+ *
+ * This is the cheap, default verification in a SOC — the well-oiled path.
+ * If Trivy/Grype/Semgrep/your-detector raised the alert, the strongest
+ * cheap signal that the patch worked is that the same scan no longer
+ * reports it.
+ */
+import { Effect } from "effect"
+
+import { type Finding, Verdict } from "../models.js"
+import type { GitWorkspace } from "../workspace.js"
+import {
+  renderCommand,
+  runCommand,
+  truncateFeedback,
+  type Verifier,
+} from "./base.js"
+
+export interface RescanOptions {
+  /**
+   * Shell command with `{workspace}` and `{finding_id}` placeholders, e.g.
+   *   "trivy fs --scanners vuln --format json {workspace}"
+   *   "semgrep scan --config auto --json {workspace}"
+   */
+  readonly commandTemplate: string
+  /**
+   * - "finding-absent" (default): finding.id does not appear in scan output.
+   *   Correct for scanners that list finding ids (CVE ids, rule ids).
+   * - "exit-zero": the command exits 0. Correct for scanners run with a
+   *   fail-on-findings flag scoped to this finding.
+   */
+  readonly passWhen?: "finding-absent" | "exit-zero"
+  readonly timeoutSeconds?: number
+  readonly name?: string
+}
+
+export const RescanVerifier = (options: RescanOptions): Verifier => {
+  const {
+    commandTemplate,
+    passWhen = "finding-absent",
+    timeoutSeconds = 600,
+    name = "rescan",
+  } = options
+  return {
+    name,
+    verify: (finding: Finding, workspace: GitWorkspace) =>
+      runCommand(
+        renderCommand(commandTemplate, finding, workspace),
+        workspace,
+        timeoutSeconds,
+      ).pipe(
+        Effect.map((result) => {
+          const passed =
+            passWhen === "exit-zero"
+              ? result.exitCode === 0
+              : !result.output.includes(finding.id)
+          return passed
+            ? Verdict({
+                passed: true,
+                verifier: name,
+                summary: `detector no longer reports ${finding.id}`,
+              })
+            : Verdict({
+                passed: false,
+                verifier: name,
+                summary: `detector still reports ${finding.id}`,
+                feedback: truncateFeedback(result.output),
+              })
+        }),
+        Effect.catchTag("CommandTimeoutError", (e) =>
+          Effect.succeed(
+            Verdict({
+              passed: false,
+              verifier: name,
+              summary: `rescan timed out after ${e.timeoutSeconds}s`,
+              feedback: `Rescan command timed out: ${e.command}`,
+            }),
+          ),
+        ),
+      ),
+  }
+}

--- a/src/socbench/patchloop/src/workspace.ts
+++ b/src/socbench/patchloop/src/workspace.ts
@@ -1,0 +1,197 @@
+/**
+ * Workspace: a git checkout the harness patches and verifies in place.
+ *
+ * The loop repairs on top of the current patched state rather than resetting
+ * between attempts, so the workspace's job is small: apply exact edits,
+ * report the cumulative diff vs the baseline commit, and hard-reset only
+ * when asked (patch application failure, or caller wants a clean slate).
+ */
+import { execFile } from "node:child_process"
+import * as fs from "node:fs/promises"
+import * as path from "node:path"
+import { Effect } from "effect"
+
+import {
+  type EditPatch,
+  PatchApplicationError,
+  WorkspaceError,
+} from "./models.js"
+
+const git = (
+  root: string,
+  ...args: ReadonlyArray<string>
+): Effect.Effect<string, WorkspaceError> =>
+  Effect.async<string, WorkspaceError>((resume) => {
+    const child = execFile(
+      "git",
+      ["-C", root, ...args],
+      { maxBuffer: 64 * 1024 * 1024 },
+      (error, stdout, stderr) => {
+        if (error) {
+          resume(
+            Effect.fail(
+              new WorkspaceError({
+                message: `git ${args[0]} failed: ${stderr.trim() || error.message}`,
+                cause: error,
+              }),
+            ),
+          )
+        } else {
+          resume(Effect.succeed(stdout))
+        }
+      },
+    )
+    return Effect.sync(() => child.kill("SIGKILL"))
+  })
+
+const tryFs = <A>(message: string, run: () => Promise<A>) =>
+  Effect.tryPromise({
+    try: run,
+    catch: (cause) => new WorkspaceError({ message, cause }),
+  })
+
+export class GitWorkspace {
+  private readonly createdPaths = new Set<string>()
+
+  private constructor(
+    readonly root: string,
+    /** resolved commit hash patches diff against */
+    readonly baselineRef: string,
+  ) {}
+
+  /** `baselineRef` is the commit patches diff against. */
+  static make = (
+    root: string,
+    baselineRef = "HEAD",
+  ): Effect.Effect<GitWorkspace, WorkspaceError> =>
+    Effect.gen(function* () {
+      const resolved = path.resolve(root)
+      const gitDir = yield* tryFs(`cannot stat ${resolved}/.git`, () =>
+        fs.stat(path.join(resolved, ".git")).catch(() => null),
+      )
+      if (gitDir === null) {
+        return yield* new WorkspaceError({
+          message: `${resolved} is not a git checkout`,
+        })
+      }
+      const baseline = yield* git(resolved, "rev-parse", baselineRef)
+      return new GitWorkspace(resolved, baseline.trim())
+    })
+
+  // -- file access ---------------------------------------------------------
+
+  read = (relPath: string): Effect.Effect<string, WorkspaceError> =>
+    this.safePath(relPath).pipe(
+      Effect.catchTag(
+        "PatchApplicationError",
+        (e) => new WorkspaceError({ message: e.message }),
+      ),
+      Effect.flatMap((abs) =>
+        tryFs(`cannot read ${relPath}`, () => fs.readFile(abs, "utf8")),
+      ),
+    )
+
+  exists = (relPath: string): Effect.Effect<boolean, never> =>
+    Effect.promise(() =>
+      fs
+        .stat(path.resolve(this.root, relPath))
+        .then(() => true)
+        .catch(() => false),
+    )
+
+  listFiles = (): Effect.Effect<ReadonlyArray<string>, WorkspaceError> =>
+    git(this.root, "ls-files", "--cached").pipe(
+      Effect.map((out) => out.split("\n").filter((line) => line.trim() !== "")),
+    )
+
+  // -- mutation --------------------------------------------------------------
+
+  /** Apply exact search/replace edits. All-or-nothing per patch. */
+  apply = (
+    patch: EditPatch,
+  ): Effect.Effect<void, PatchApplicationError | WorkspaceError> => {
+    const self = this
+    return Effect.gen(function* () {
+      const staged: Array<{ abs: string; content: string }> = []
+      const created: Array<string> = []
+      for (const edit of patch.edits) {
+        const abs = yield* self.safePath(edit.path)
+        if (edit.search === "") {
+          if (yield* self.exists(edit.path)) {
+            return yield* new PatchApplicationError({
+              message: `empty search targets existing file ${edit.path}`,
+            })
+          }
+          staged.push({ abs, content: edit.replace })
+          created.push(edit.path)
+          continue
+        }
+        const content: string = yield* tryFs(`cannot read ${edit.path}`, () =>
+          fs.readFile(abs, "utf8"),
+        ).pipe(
+          Effect.catchTag(
+            "WorkspaceError",
+            (e) => new PatchApplicationError({ message: e.message }),
+          ),
+        )
+        const occurrences = content.split(edit.search).length - 1
+        if (occurrences !== 1) {
+          return yield* new PatchApplicationError({
+            message: `search text matched ${occurrences} times in ${edit.path} (need exactly 1)`,
+          })
+        }
+        staged.push({ abs, content: content.replace(edit.search, edit.replace) })
+      }
+      for (const { abs, content } of staged) {
+        yield* tryFs(`cannot write ${abs}`, async () => {
+          await fs.mkdir(path.dirname(abs), { recursive: true })
+          await fs.writeFile(abs, content, "utf8")
+        })
+      }
+      for (const rel of created) self.createdPaths.add(rel)
+    })
+  }
+
+  /** Discard all changes back to the baseline ref. */
+  reset = (): Effect.Effect<void, WorkspaceError> =>
+    Effect.gen(this, function* () {
+      yield* git(this.root, "checkout", this.baselineRef, "--", ".")
+      yield* git(this.root, "clean", "-fd")
+      this.createdPaths.clear()
+    })
+
+  /**
+   * Cumulative diff vs baseline.
+   *
+   * Untracked files are included only if a patch created them — verifier
+   * build artifacts (bytecode, scan caches) stay out.
+   */
+  diff = (): Effect.Effect<string, WorkspaceError> =>
+    Effect.gen(this, function* () {
+      const created: Array<string> = []
+      for (const rel of [...this.createdPaths].sort()) {
+        if (yield* this.exists(rel)) created.push(rel)
+      }
+      if (created.length === 0) {
+        return yield* git(this.root, "diff", this.baselineRef)
+      }
+      yield* git(this.root, "add", "-N", "--", ...created)
+      return yield* git(this.root, "diff", this.baselineRef).pipe(
+        Effect.ensuring(Effect.ignore(git(this.root, "reset", "-q"))),
+      )
+    })
+
+  // -- internals ---------------------------------------------------------------
+
+  private safePath = (
+    relPath: string,
+  ): Effect.Effect<string, PatchApplicationError> => {
+    const abs = path.resolve(this.root, relPath)
+    if (abs !== this.root && !abs.startsWith(this.root + path.sep)) {
+      return new PatchApplicationError({
+        message: `path escapes workspace: ${relPath}`,
+      })
+    }
+    return Effect.succeed(abs)
+  }
+}

--- a/src/socbench/patchloop/test/harness.test.ts
+++ b/src/socbench/patchloop/test/harness.test.ts
@@ -1,0 +1,264 @@
+/**
+ * Loop-semantics tests with fake patcher/verifier — no LLM, no scanners.
+ *
+ * These pin the behaviors that made the loop work on PatchEval:
+ * empty-patch rejection, repair-on-top-of-patched-state, reset only on
+ * apply failure, verifier crash != pass, bounded attempts, fail-fast
+ * chains.
+ */
+import { execFileSync } from "node:child_process"
+import * as fs from "node:fs/promises"
+import * as os from "node:os"
+import * as path from "node:path"
+import { Effect, Logger } from "effect"
+import { afterEach, describe, expect, it } from "vitest"
+
+import {
+  type EditPatch,
+  Finding,
+  GitWorkspace,
+  OrderedVerifier,
+  type Patcher,
+  RemediationHarness,
+  Verdict,
+  type Verifier,
+} from "../src/index.js"
+
+const FINDING = new Finding({
+  id: "CVE-2099-0001",
+  kind: "cve",
+  title: "hardcoded credential",
+  description: "app.py contains a hardcoded password",
+  locations: ["app.py"],
+})
+
+const VULNERABLE = 'PASSWORD = "hunter2"\n\ndef connect():\n    return PASSWORD\n'
+
+const tmpDirs: Array<string> = []
+afterEach(async () => {
+  while (tmpDirs.length > 0) {
+    await fs.rm(tmpDirs.pop()!, { recursive: true, force: true })
+  }
+})
+
+const makeRepo = async (): Promise<GitWorkspace> => {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), "patchloop-"))
+  tmpDirs.push(root)
+  await fs.writeFile(path.join(root, "app.py"), VULNERABLE)
+  const g = (...args: Array<string>) =>
+    execFileSync("git", ["-C", root, ...args], { stdio: "pipe" })
+  g("init", "-q")
+  g("-c", "user.email=t@t", "-c", "user.name=t", "add", "-A")
+  g("-c", "user.email=t@t", "-c", "user.name=t", "commit", "-qm", "base")
+  return run(GitWorkspace.make(root))
+}
+
+// Every effect in tests runs with logging silenced.
+const run = <A, E>(effect: Effect.Effect<A, E>): Promise<A> =>
+  Effect.runPromise(effect.pipe(Effect.provide(Logger.remove(Logger.defaultLogger))))
+
+/** Returns queued patches; records the feedback it was called with. */
+class ScriptedPatcher implements Patcher {
+  readonly feedbackSeen: Array<string | null> = []
+  constructor(private readonly patches: Array<EditPatch>) {}
+
+  propose = (
+    _finding: Finding,
+    _workspace: GitWorkspace,
+    feedback: string | null,
+  ) =>
+    Effect.sync(() => {
+      this.feedbackSeen.push(feedback)
+      return this.patches.shift()!
+    })
+}
+
+/** Passes when the hardcoded password is gone from app.py. */
+const MarkerVerifier = (
+  onVerify?: (workspace: GitWorkspace) => Promise<void>,
+): Verifier => ({
+  name: "marker",
+  verify: (_finding, workspace) =>
+    Effect.gen(function* () {
+      if (onVerify) yield* Effect.promise(() => onVerify(workspace))
+      const content = yield* workspace.read("app.py")
+      return content.includes("hunter2")
+        ? Verdict({
+            passed: false,
+            verifier: "marker",
+            summary: "still vulnerable",
+            feedback: "hunter2 still present",
+          })
+        : Verdict({ passed: true, verifier: "marker", summary: "clean" })
+    }),
+})
+
+const patch = (edits: EditPatch["edits"]): EditPatch => ({
+  edits,
+  rationale: "",
+})
+
+const GOOD_PATCH = patch([
+  {
+    path: "app.py",
+    search: 'PASSWORD = "hunter2"',
+    replace: 'import os\nPASSWORD = os.environ["APP_PASSWORD"]',
+  },
+])
+const NOOP_PATCH = patch([])
+const BAD_APPLY_PATCH = patch([
+  { path: "app.py", search: "text that does not exist", replace: "x" },
+])
+const INEFFECTIVE_PATCH = patch([
+  { path: "app.py", search: "def connect():", replace: "def connect():  # reviewed" },
+])
+
+describe("RemediationHarness loop", () => {
+  it("succeeds on the first attempt", async () => {
+    const ws = await makeRepo()
+    const harness = RemediationHarness({
+      patcher: new ScriptedPatcher([GOOD_PATCH]),
+      verifier: MarkerVerifier(),
+    })
+    const result = await run(harness.run(FINDING, ws))
+    expect(result.success).toBe(true)
+    expect(result.attempts).toHaveLength(1)
+    expect(result.finalDiff).toContain("APP_PASSWORD")
+  })
+
+  it("never counts an empty patch as success and triggers feedback", async () => {
+    const ws = await makeRepo()
+    const patcher = new ScriptedPatcher([NOOP_PATCH, GOOD_PATCH])
+    const result = await run(
+      RemediationHarness({ patcher, verifier: MarkerVerifier() }).run(FINDING, ws),
+    )
+    expect(result.success).toBe(true)
+    expect(result.attempts).toHaveLength(2)
+    expect(result.attempts[0]!.error).toBe("empty patch")
+    expect(patcher.feedbackSeen[1]).toContain("no effective edits")
+  })
+
+  it("repairs on top of the patched state, not from a reset", async () => {
+    const ws = await makeRepo()
+    const patcher = new ScriptedPatcher([INEFFECTIVE_PATCH, GOOD_PATCH])
+    const result = await run(
+      RemediationHarness({ patcher, verifier: MarkerVerifier() }).run(FINDING, ws),
+    )
+    expect(result.success).toBe(true)
+    // both edits present: the loop did not reset between attempts
+    const content = await run(ws.read("app.py"))
+    expect(content).toContain("# reviewed")
+    expect(content).toContain("APP_PASSWORD")
+    // repair prompt carried the verbatim failure and the current diff
+    expect(patcher.feedbackSeen[1]).toContain("hunter2 still present")
+    expect(patcher.feedbackSeen[1]).toContain("# reviewed")
+  })
+
+  it("resets the workspace when a patch fails to apply", async () => {
+    const ws = await makeRepo()
+    const patcher = new ScriptedPatcher([BAD_APPLY_PATCH, GOOD_PATCH])
+    const result = await run(
+      RemediationHarness({ patcher, verifier: MarkerVerifier() }).run(FINDING, ws),
+    )
+    expect(result.success).toBe(true)
+    expect(result.attempts[0]!.error).toContain("apply error")
+    expect(patcher.feedbackSeen[1]).toContain("reset to the original code")
+  })
+
+  it("includes patch-created files in the diff but not verifier artifacts", async () => {
+    const newFilePatch = patch([
+      GOOD_PATCH.edits[0]!,
+      { path: "security_notes.md", search: "", replace: "rotated creds\n" },
+    ])
+    // simulates a scanner dropping a cache file in the workspace
+    const artifactVerifier = MarkerVerifier(async (workspace) => {
+      await fs.writeFile(
+        path.join(workspace.root, "scan-cache.bin"),
+        Buffer.from([0, 106, 117, 110, 107]),
+      )
+    })
+    const ws = await makeRepo()
+    const result = await run(
+      RemediationHarness({
+        patcher: new ScriptedPatcher([newFilePatch]),
+        verifier: artifactVerifier,
+      }).run(FINDING, ws),
+    )
+    expect(result.success).toBe(true)
+    expect(result.finalDiff).toContain("security_notes.md")
+    expect(result.finalDiff).not.toContain("scan-cache.bin")
+  })
+
+  it("stops after maxAttempts", async () => {
+    const ws = await makeRepo()
+    const patcher = new ScriptedPatcher([NOOP_PATCH, NOOP_PATCH, NOOP_PATCH])
+    const result = await run(
+      RemediationHarness({
+        patcher,
+        verifier: MarkerVerifier(),
+        maxAttempts: 3,
+      }).run(FINDING, ws),
+    )
+    expect(result.success).toBe(false)
+    expect(result.attempts).toHaveLength(3)
+  })
+
+  it("treats a crashing verifier as a failure, never a pass", async () => {
+    const crashing: Verifier = {
+      name: "crash",
+      verify: () => Effect.die(new Error("scanner unavailable")),
+    }
+    const ws = await makeRepo()
+    const result = await run(
+      RemediationHarness({
+        patcher: new ScriptedPatcher([GOOD_PATCH]),
+        verifier: crashing,
+        maxAttempts: 1,
+      }).run(FINDING, ws),
+    )
+    expect(result.success).toBe(false)
+    expect(result.attempts[0]!.verdict!.summary).toContain("verifier crashed")
+    expect(result.attempts[0]!.verdict!.summary).toContain("scanner unavailable")
+  })
+})
+
+describe("OrderedVerifier", () => {
+  const check = (name: string, passed: boolean, calls: Array<string>): Verifier => ({
+    name,
+    verify: () =>
+      Effect.sync(() => {
+        calls.push(name)
+        return Verdict({
+          passed,
+          verifier: name,
+          summary: name,
+          feedback: `${name} output`,
+        })
+      }),
+  })
+
+  it("fails fast and skips expensive checks", async () => {
+    const calls: Array<string> = []
+    const chain = OrderedVerifier([
+      check("rescan", false, calls),
+      check("reproduce", true, calls),
+    ])
+    const ws = await makeRepo()
+    const verdict = await run(chain.verify(FINDING, ws))
+    expect(verdict.passed).toBe(false)
+    expect(calls).toEqual(["rescan"])
+    expect(verdict.feedback).toContain("failed check: rescan")
+  })
+
+  it("passes when every check passes", async () => {
+    const calls: Array<string> = []
+    const chain = OrderedVerifier([
+      check("a", true, calls),
+      check("b", true, calls),
+    ])
+    const ws = await makeRepo()
+    const verdict = await run(chain.verify(FINDING, ws))
+    expect(verdict.passed).toBe(true)
+    expect(calls).toEqual(["a", "b"])
+  })
+})

--- a/src/socbench/patchloop/tsconfig.json
+++ b/src/socbench/patchloop/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": ["ES2022"],
+    "types": ["node"],
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "strict": true,
+    "exactOptionalPropertyTypes": true,
+    "noUncheckedIndexedAccess": true,
+    "declaration": true,
+    "outDir": "dist",
+    "rootDir": "src",
+    "skipLibCheck": true
+  },
+  "include": ["src"]
+}


### PR DESCRIPTION
## Summary

- Add PatchLoop, the TypeScript verification-loop remediation harness, at `src/socbench/patchloop` (source, tests, examples; MIT-licensed subdirectory)
- Restructure the website into capability pages: `/detection/` and a new `/patchloop/` page with the PatchEval results and the PatchEval-Verified disclaimer
- Rewrite the README around the socbench.org vision: capabilities map, Detection and PatchLoop sections, announcement banner, license split

Branch is rebased on main (open-source adapter + Dependabot bumps included); 159 tests pass. Note: merging deploys the new site to socbench.org via Pages.

Follow-up: repo restructure and install extras tracked in #12.

🤖 Generated with [Claude Code](https://claude.com/claude-code)