### PR TITLE
Add security policy, RFC 9116 security.txt, and Dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,35 @@
+version: 2
+
+# Dependabot version updates. Security updates (patches for open Dependabot
+# alerts) are enabled separately in repo settings and do not require an entry
+# here; these schedules keep the lockfiles from drifting far enough behind that
+# a security bump turns into a major-version migration.
+updates:
+  # Python benchmark package. uv.lock is the resolved manifest; pyproject.toml
+  # holds the declared ranges.
+  - package-ecosystem: "uv"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    groups:
+      python-minor-and-patch:
+        update-types: ["minor", "patch"]
+
+  # PatchLoop (TypeScript harness).
+  - package-ecosystem: "npm"
+    directory: "/src/socbench/patchloop"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    groups:
+      npm-minor-and-patch:
+        update-types: ["minor", "patch"]
+
+  # Pinned action versions in .github/workflows. Keeping these current matters
+  # because they run with pages: write and id-token: write on the deploy job.
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -6,6 +6,14 @@ on:
     paths:
       - "docs/website/**"
       - ".github/workflows/pages.yml"
+  # Weekly no-op redeploy. Its real job is to run the security.txt expiry
+  # check on a clock: that guard exists to notice time passing, and a
+  # push-only trigger would never fire it during a quiet stretch. A failure
+  # here blocks the redeploy and leaves the already-published site serving.
+  # Note that GitHub disables scheduled workflows after 60 days of repo
+  # inactivity, so this is a backstop, not a guarantee.
+  schedule:
+    - cron: "0 9 * * 1"
   workflow_dispatch:
 
 permissions:
@@ -34,6 +42,59 @@ jobs:
             echo "::error::em-dash / en-dash found in shipped copy. Substitute periods, colons, or hyphens."
             exit 1
           fi
+      - name: Validate .well-known/security.txt
+        # RFC 9116 treats an expired security.txt as invalid, which is a worse
+        # state than not publishing one at all, so the deploy refuses to ship a
+        # file that is expired or about to be. Warns from 60 days out, fails
+        # under 30, which leaves a month of visible warnings before the gate
+        # actually blocks a deploy. Also enforces the two structural rules the
+        # RFC states outright: at least one Contact, exactly one Expires.
+        run: |
+          python3 - <<'PY'
+          import datetime, sys
+
+          PATH = "docs/website/.well-known/security.txt"
+          WARN_DAYS, FAIL_DAYS = 60, 30
+
+          fields = {}
+          for line in open(PATH, encoding="utf-8"):
+              line = line.strip()
+              if not line or line.startswith("#") or ":" not in line:
+                  continue
+              key, value = line.split(":", 1)
+              fields.setdefault(key.strip(), []).append(value.strip())
+
+          errors = []
+          if not fields.get("Contact"):
+              errors.append("security.txt needs at least one Contact field (RFC 9116 s2.5.3).")
+
+          expires = fields.get("Expires", [])
+          if len(expires) != 1:
+              errors.append(
+                  f"security.txt needs exactly one Expires field, found {len(expires)} (RFC 9116 s2.5.5)."
+              )
+          else:
+              now = datetime.datetime.now(datetime.timezone.utc)
+              when = datetime.datetime.fromisoformat(expires[0].replace("Z", "+00:00"))
+              days = (when - now).days
+              if days < FAIL_DAYS:
+                  state = "has expired" if days < 0 else f"expires in {days} days"
+                  errors.append(
+                      f"security.txt {state} ({expires[0]}). Renew it and bump Expires "
+                      f"before deploying; an expired file is treated as invalid."
+                  )
+              elif days < WARN_DAYS:
+                  print(
+                      f"::warning::security.txt expires in {days} days ({expires[0]}). "
+                      f"Renew it; the deploy starts failing at {FAIL_DAYS} days."
+                  )
+              else:
+                  print(f"security.txt valid for {days} more days.")
+
+          for error in errors:
+              print(f"::error::{error}")
+          sys.exit(1 if errors else 0)
+          PY
       - name: Cache-bust static assets with commit SHA
         # Append ?v=<short-sha> to css/js references in every deployed HTML file
         # so browsers refetch on every deploy instead of serving stale files.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,129 @@
+# Security Policy
+
+SOCBench is an open benchmark and a set of harnesses for AI in cybersecurity
+operations. We take security reports seriously and we would rather hear about a
+problem early and informally than not at all.
+
+Machine-readable contact information is published at
+[socbench.org/.well-known/security.txt](https://socbench.org/.well-known/security.txt)
+per [RFC 9116](https://www.rfc-editor.org/rfc/rfc9116).
+
+## Reporting a vulnerability
+
+**Please do not open a public GitHub issue for a security problem.**
+
+Two private channels, in order of preference:
+
+1. **GitHub private vulnerability reporting (preferred).**
+   [Open a draft advisory](https://github.com/DeepTempo/socbench/security/advisories/new).
+   This keeps the report private, keeps the whole discussion attached to the
+   repository, and is the path that lets us request a CVE if one is warranted.
+2. **Email.** [security@deeptempo.ai](mailto:security@deeptempo.ai). If you want
+   to encrypt, say so in a first message with no sensitive detail and we will
+   arrange a key.
+
+A useful report usually includes:
+
+- The affected component (the `socbench` Python package, PatchLoop, the CI
+  workflows, or socbench.org) and the commit SHA you tested.
+- What an attacker gains, stated plainly. "Reads any file on the host" is more
+  useful than a severity label.
+- Reproduction steps, ideally against the mock provider so we can reproduce
+  without spending API budget.
+- Any proof of concept, and whether you have shared it anywhere else.
+
+## What to expect
+
+| Stage | Target |
+| --- | --- |
+| Acknowledgment that a human has read it | 3 business days |
+| Initial triage, severity, and whether we agree it is in scope | 10 business days |
+| Fix or documented mitigation for accepted reports | 90 days from triage |
+
+If a report is accepted, we will keep you updated as the fix progresses and
+will coordinate timing with you before any public disclosure. If we disagree
+that something is a vulnerability, we will say so and explain why, rather than
+letting the thread go quiet.
+
+We do not run a paid bug bounty. We do credit reporters (see
+[Acknowledgments](#acknowledgments)).
+
+## Supported versions
+
+SOCBench is pre-1.0 and has no released versions or maintained release
+branches. **Only the latest commit on `main` is supported.** Fixes land on
+`main`; there are no backports. If you are running a pinned older commit,
+expect to move forward to pick up a fix.
+
+## Scope
+
+### In scope
+
+- **Code execution or file access outside the intended boundary.** PatchLoop
+  applies model-generated patches and runs verifier commands by design (see
+  [Known design constraints](#known-design-constraints)). A way to reach code
+  execution, path traversal, or host file access *without* the operator opting
+  into it, or a way to escape the workspace that the documented setup is
+  supposed to contain, is in scope.
+- **Credential exposure.** Provider API keys (`OPENAI_API_KEY`,
+  `ANTHROPIC_API_KEY`, `GOOGLE_API_KEY`) leaking into logs, run artifacts,
+  scored output, error messages, or anything the repo commits or publishes.
+- **Prompt injection with a concrete security consequence.** Content in a
+  finding, a dataset record, or a tool result that steers an agent into an
+  action outside its persona's read-only tool scope, exfiltrates credentials,
+  or escapes its dollar or turn budget. The consequence matters here; see
+  the out-of-scope note on model behavior below.
+- **Input handling at trust boundaries.** Deserialization, schema decoding, or
+  path handling that mishandles untrusted findings, JSON, or corpus files.
+- **Vulnerable dependencies** that are actually reachable from shipped code
+  paths.
+- **Supply chain and CI.** Workflow injection, privilege escalation in
+  `.github/workflows`, or anything that could tamper with the GitHub Pages
+  deployment or the published artifacts.
+- **socbench.org** itself, to the extent a static site can be affected.
+
+### Out of scope
+
+- **Model behavior.** Jailbreaks, refusals, hallucinations, or unsafe
+  generations from Anthropic, OpenAI, Google, or any self-hosted model. Report
+  those to the model provider. We are interested only in cases where our
+  harness turns model output into a concrete security consequence on the host.
+- **PatchLoop executing patches and verifier commands.** This is the documented
+  purpose of the tool, not a vulnerability. See below.
+- **Benchmark results.** Disagreements about scores, methodology, or fairness
+  are welcome, but they belong in a public GitHub issue, not a security report.
+- **Missing HTTP security headers, CSP, or cookie flags on socbench.org.** It
+  is a static site on GitHub Pages with no authentication, no cookies, and no
+  user data.
+- **Volumetric denial of service**, rate-limit exhaustion, and load testing
+  against socbench.org or against provider APIs using our code.
+- **Self-XSS**, issues that need a fully compromised host or a
+  physically-present attacker, and social engineering of maintainers.
+- **Automated scanner output** with no demonstrated impact.
+
+## Known design constraints
+
+These are deliberate properties of the software. Reporting them as
+vulnerabilities will get a polite pointer back to this section, but a
+demonstrated *bypass* of any of them is very much in scope.
+
+- **PatchLoop runs untrusted code on purpose.** It asks a model for a patch,
+  applies it to a git workspace, and executes operator-supplied verifier
+  commands (scanners, test suites, exploit reproductions) against the result.
+  Run it in a container or a disposable VM, against repositories you trust,
+  with credentials scoped to that job. Command timeouts kill the whole process
+  group, which bounds runaway verifiers; they are not a security sandbox.
+- **The benchmark corpus is data, not a trust boundary.** Network flow records
+  and findings are attacker-influenced by nature. The harness constrains what
+  an agent can *do* with them through read-only, persona-scoped tools and
+  bounded budgets. Treat any gap in that constraint as in scope.
+- **Provider API keys are read from the shell environment.** The repo never
+  stores them. Anything that causes them to be written to disk or emitted in
+  output is a bug we want to hear about.
+
+## Acknowledgments
+
+We credit everyone who reports a valid security issue, unless they ask to stay
+anonymous. Reporters are listed here once the corresponding fix has shipped.
+
+No reports yet. This section will be updated as they come in.

--- a/docs/website/.well-known/security.txt
+++ b/docs/website/.well-known/security.txt
@@ -1,0 +1,14 @@
+# SOCBench - security.txt
+# Standard: RFC 9116 (https://www.rfc-editor.org/rfc/rfc9116)
+# Canonical location: https://socbench.org/.well-known/security.txt
+#
+# To report a vulnerability, please use GitHub private vulnerability reporting
+# (preferred) or the security email below. Do NOT open public GitHub issues.
+
+Contact: https://github.com/DeepTempo/socbench/security/advisories/new
+Contact: mailto:security@deeptempo.ai
+Expires: 2027-08-25T00:00:00.000Z
+Policy: https://github.com/DeepTempo/socbench/blob/main/SECURITY.md
+Acknowledgments: https://github.com/DeepTempo/socbench/blob/main/SECURITY.md#acknowledgments
+Preferred-Languages: en
+Canonical: https://socbench.org/.well-known/security.txt


### PR DESCRIPTION
## Why

There was no `SECURITY.md`, no `security.txt`, and no private reporting channel on this repo, so a researcher who found something had no path other than opening a public issue.

## What is here

**`SECURITY.md`** scoped to what SOCBench actually is (a benchmark package, PatchLoop, and a static site), rather than a generic template. The notable section is **Known design constraints**: PatchLoop applies model-generated patches and executes operator-supplied verifier commands *by design*, so that is documented as intended behavior with container/VM guidance, while a bypass of the documented isolation stays explicitly in scope. Model jailbreaks are redirected to the model provider, benchmark score disputes to public issues, and static-site security headers are out of scope. Supported versions says only latest `main`, since no tags or releases exist.

**`docs/website/.well-known/security.txt`** per [RFC 9116](https://www.rfc-editor.org/rfc/rfc9116), served from the Pages site at `socbench.org`. Lists the GitHub advisory URL first and `security@deeptempo.ai` as fallback.

**Expiry guard in `pages.yml`.** An expired `security.txt` is treated as invalid by tooling, which is a worse state than publishing none at all. The new step fails the deploy under 30 days from expiry, warns from 60, and enforces the two structural rules the RFC states outright (at least one `Contact`, exactly one `Expires`). Verified against five crafted inputs:

| Case | Result |
|---|---|
| Current file, 364 days out | pass |
| 45 days out | `::warning::`, exit 0 |
| 10 days out | `::error::`, exit 1 |
| Already expired | `::error::`, exit 1 |
| No `Contact` + duplicate `Expires` | both errors, exit 1 |

A weekly `schedule` trigger comes with it, because the guard exists to notice time passing and a push-only trigger would never fire during a quiet stretch. It is a no-op redeploy; a failure blocks it and leaves the published site serving. GitHub disables scheduled workflows after 60 days of repo inactivity, so treat it as a backstop rather than a guarantee.

**`.github/dependabot.yml`** for `uv`, `npm` (patchloop), and `github-actions`. The actions entry matters because the deploy job runs with `pages: write` and `id-token: write`.

## Repo settings enabled (not in this diff)

All four were disabled. The 29 alerts in 4efdde4 were fixed by hand.

- Private vulnerability reporting
- Secret scanning
- Push protection
- Dependabot security updates

## Verification

- Both YAML files parse; heredoc delimiters resolve to column 0 after block-scalar de-indentation.
- Existing em-dash lint still passes across all site HTML and JS.
- `security.txt` parses with one `Expires` at 364 days out, inside the RFC's under-one-year requirement.

## Note

`security.txt` goes live at `socbench.org/.well-known/security.txt` only once this merges to `main`, since the Pages workflow is gated on pushes to that branch. Worth one `curl` afterward to confirm the dot-directory survives the artifact upload. I expect it to, since `.nojekyll` already deploys from the same directory, but it is cheap to confirm rather than assume.

🤖 Generated with [Claude Code](https://claude.com/claude-code)